### PR TITLE
Bp5 random fix zero

### DIFF
--- a/bindings/C/adios2/c/adios2_c_engine.cpp
+++ b/bindings/C/adios2/c/adios2_c_engine.cpp
@@ -640,6 +640,154 @@ adios2_error adios2_lock_reader_selections(adios2_engine *engine)
     }
 }
 
+adios2_varinfo *adios2_inquire_blockinfo(adios2_engine *engine,
+                                         adios2_variable *variable,
+                                         const size_t step)
+{
+    auto lf_CopyDims = [](const std::vector<size_t> &dims) -> size_t * {
+        size_t *a = nullptr;
+        size_t ndims = dims.size();
+        if (ndims > 0)
+        {
+            a = (size_t *)malloc(dims.size() * sizeof(size_t));
+            std::memcpy(a, dims.data(), dims.size() * sizeof(size_t));
+        }
+        return a;
+    };
+
+    adios2_varinfo *varinfo = NULL;
+
+    try
+    {
+        adios2::helper::CheckForNullptr(
+            engine, "for adios2_engine, in call to adios2_inquire_blockinfo");
+
+        adios2::core::Engine *engineCpp =
+            reinterpret_cast<adios2::core::Engine *>(engine);
+
+        if (engineCpp->m_EngineType == "NULL")
+        {
+            return NULL;
+        }
+        adios2::helper::CheckForNullptr(variable,
+                                        "for adios2_variable, in call "
+                                        "to adios2_get");
+
+        adios2::core::VariableBase *variableBase =
+            reinterpret_cast<adios2::core::VariableBase *>(variable);
+
+        const adios2::DataType type(variableBase->m_Type);
+
+        const auto minBlocksInfo =
+            engineCpp->MinBlocksInfo(*variableBase, step);
+
+        if (minBlocksInfo)
+        {
+            varinfo = (adios2_varinfo *)malloc(sizeof(adios2_varinfo));
+            varinfo->nblocks = minBlocksInfo->BlocksInfo.size();
+            varinfo->BlocksInfo = (adios2_blockinfo *)malloc(
+                varinfo->nblocks * sizeof(adios2_blockinfo));
+            auto *b = varinfo->BlocksInfo;
+
+            varinfo->Dims = minBlocksInfo->Dims;
+            varinfo->Shape = minBlocksInfo->Shape;
+            varinfo->IsValue = (int)minBlocksInfo->IsValue;
+            varinfo->IsReverseDims = (int)minBlocksInfo->IsReverseDims;
+            for (size_t i = 0; i < varinfo->nblocks; ++i)
+            {
+                b[i].WriterID = minBlocksInfo->BlocksInfo[i].WriterID;
+                b[i].BlockID = minBlocksInfo->BlocksInfo[i].BlockID;
+                b[i].Start = minBlocksInfo->BlocksInfo[i].Start;
+                b[i].Count = minBlocksInfo->BlocksInfo[i].Count;
+                if (minBlocksInfo->IsValue)
+                {
+                    b[i].Value.uint64 = 0;
+                    //  = *((T *)minBlocksInfo->BlocksInfo[i].BufferP);
+                }
+                else
+                {
+                    b[i].MinUnion.uint64 = 0;
+                    //  = minBlocksInfo->BlocksInfo[i].MinUnion;
+                    b[i].MaxUnion.uint64 = 0;
+                    //  = minBlocksInfo->BlocksInfo[i].MaxUnion;
+                }
+            }
+            delete minBlocksInfo;
+            return varinfo;
+        }
+
+        /* Call the big gun Engine::BlocksInfo<T> */
+        if (type == adios2::DataType::Compound)
+        {
+            return varinfo;
+        }
+        else if (type == adios2::helper::GetDataType<std::string>())
+        {
+            const auto blocksInfo = engineCpp->BlocksInfo<std::string>(
+                *dynamic_cast<adios2::core::Variable<std::string> *>(
+                    variableBase),
+                step);
+            varinfo = (adios2_varinfo *)malloc(sizeof(adios2_varinfo));
+            varinfo->nblocks = blocksInfo.size();
+            varinfo->BlocksInfo = (adios2_blockinfo *)malloc(
+                varinfo->nblocks * sizeof(adios2_blockinfo));
+            auto *b = varinfo->BlocksInfo;
+
+            varinfo->Dims = blocksInfo[0].Shape.size();
+            varinfo->Shape = lf_CopyDims(blocksInfo[0].Shape);
+            varinfo->IsValue = (int)blocksInfo[0].IsValue;
+            varinfo->IsReverseDims = (int)blocksInfo[0].IsReverseDims;
+            for (size_t i = 0; i < varinfo->nblocks; ++i)
+            {
+                b[i].WriterID = blocksInfo[i].WriterID;
+                b[i].BlockID = blocksInfo[i].BlockID;
+                b[i].Start = lf_CopyDims(blocksInfo[i].Start);
+                b[i].Count = lf_CopyDims(blocksInfo[i].Count);
+                // minBlocksInfo->BlocksInfo[i].MinUnion;
+                b[i].MinUnion.uint64 = 0;
+                // minBlocksInfo->BlocksInfo[i].MaxUnion;
+                b[i].MaxUnion.uint64 = 0;
+                b[i].Value.str = (char *)malloc(blocksInfo[i].Value.size() + 1);
+                std::strcpy(b[i].Value.str, blocksInfo[i].Value.data());
+            };
+        }
+#define declare_template_instantiation(T)                                      \
+    else if (type == adios2::helper::GetDataType<T>())                         \
+    {                                                                          \
+        const auto blocksInfo = engineCpp->BlocksInfo<T>(                      \
+            *dynamic_cast<adios2::core::Variable<T> *>(variableBase), step);   \
+        varinfo = (adios2_varinfo *)malloc(sizeof(adios2_varinfo));            \
+        varinfo->nblocks = blocksInfo.size();                                  \
+        varinfo->BlocksInfo = (adios2_blockinfo *)malloc(                      \
+            varinfo->nblocks * sizeof(adios2_blockinfo));                      \
+        auto *b = varinfo->BlocksInfo;                                         \
+                                                                               \
+        varinfo->Dims = blocksInfo[0].Shape.size();                            \
+        varinfo->Shape = lf_CopyDims(blocksInfo[0].Shape);                     \
+        varinfo->IsValue = (int)blocksInfo[0].IsValue;                         \
+        varinfo->IsReverseDims = (int)blocksInfo[0].IsReverseDims;             \
+        for (size_t i = 0; i < varinfo->nblocks; ++i)                          \
+        {                                                                      \
+            b[i].WriterID = blocksInfo[i].WriterID;                            \
+            b[i].BlockID = blocksInfo[i].BlockID;                              \
+            b[i].Start = lf_CopyDims(blocksInfo[i].Start);                     \
+            b[i].Count = lf_CopyDims(blocksInfo[i].Count);                     \
+            b[i].MinUnion.uint64 = 0;                                          \
+            b[i].MaxUnion.uint64 = 0;                                          \
+            b[i].Value.uint64 = 0;                                             \
+        };                                                                     \
+    }
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+    }
+    catch (...)
+    {
+        adios2::helper::ExceptionToError("adios2_inquire_blockinfo");
+        return NULL;
+    }
+    return varinfo;
+}
+
 adios2_error adios2_close_by_index(adios2_engine *engine,
                                    const int transport_index)
 {

--- a/bindings/C/adios2/c/adios2_c_engine.cpp
+++ b/bindings/C/adios2/c/adios2_c_engine.cpp
@@ -733,7 +733,7 @@ adios2_varinfo *adios2_inquire_blockinfo(adios2_engine *engine,
                 varinfo->nblocks * sizeof(adios2_blockinfo));
             auto *b = varinfo->BlocksInfo;
 
-            varinfo->Dims = blocksInfo[0].Shape.size();
+            varinfo->Dims = static_cast<int>(blocksInfo[0].Shape.size());
             varinfo->Shape = lf_CopyDims(blocksInfo[0].Shape);
             varinfo->IsValue = (int)blocksInfo[0].IsValue;
             varinfo->IsReverseDims = (int)blocksInfo[0].IsReverseDims;
@@ -762,7 +762,7 @@ adios2_varinfo *adios2_inquire_blockinfo(adios2_engine *engine,
             varinfo->nblocks * sizeof(adios2_blockinfo));                      \
         auto *b = varinfo->BlocksInfo;                                         \
                                                                                \
-        varinfo->Dims = blocksInfo[0].Shape.size();                            \
+        varinfo->Dims = static_cast<int>(blocksInfo[0].Shape.size());          \
         varinfo->Shape = lf_CopyDims(blocksInfo[0].Shape);                     \
         varinfo->IsValue = (int)blocksInfo[0].IsValue;                         \
         varinfo->IsReverseDims = (int)blocksInfo[0].IsReverseDims;             \

--- a/bindings/C/adios2/c/adios2_c_engine.h
+++ b/bindings/C/adios2/c/adios2_c_engine.h
@@ -264,6 +264,16 @@ adios2_error adios2_lock_writer_definitions(adios2_engine *engine);
  */
 adios2_error adios2_lock_reader_selections(adios2_engine *engine);
 
+/**
+ * Get the list of blocks for a variable in a given step.
+ * In Streaming mode, step is unused, always the current step is processed.
+ * @return Newly allocated adios2_varinfo structure, nullptr if step does not
+ * exist. The pointer must be freed by user
+ */
+adios2_varinfo *adios2_inquire_blockinfo(adios2_engine *engine,
+                                         adios2_variable *variable,
+                                         const size_t step);
+
 #ifdef __cplusplus
 } // end extern C
 #endif

--- a/bindings/C/adios2/c/adios2_c_types.h
+++ b/bindings/C/adios2/c/adios2_c_types.h
@@ -149,6 +149,43 @@ static const size_t adios2_string_array_element_max_size = 4096;
 
 static const size_t adios2_local_value_dim = SIZE_MAX - 2;
 
+union adios2_PrimitiveStdtypeUnion
+{
+    int8_t int8;
+    int16_t int16;
+    int32_t int32;
+    int64_t int64;
+    uint8_t uint8;
+    uint16_t uint16;
+    uint32_t uint32;
+    uint64_t uint64;
+    float f;
+    double d;
+    long double ld;
+    char *str;
+};
+
+typedef struct
+{
+    int WriterID;
+    size_t BlockID;
+    size_t *Start;
+    size_t *Count;
+    union adios2_PrimitiveStdtypeUnion MinUnion;
+    union adios2_PrimitiveStdtypeUnion MaxUnion;
+    union adios2_PrimitiveStdtypeUnion Value;
+} adios2_blockinfo;
+
+typedef struct
+{
+    int Dims;
+    size_t *Shape;
+    int IsValue;
+    int IsReverseDims;
+    size_t nblocks;
+    adios2_blockinfo *BlocksInfo;
+} adios2_varinfo;
+
 #ifdef __cplusplus
 } // end extern C
 #endif

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -255,7 +255,8 @@ public:
     /**
      * Open an Engine to start heavy-weight input/output operations.
      * @param name unique engine identifier
-     * @param mode adios2::Mode::Write, adios2::Mode::Read, or
+     * @param mode adios2::Mode::Write, adios2::Mode::Read,
+     * 		   adios2::Mode::ReadStreaming, or
      *             adios2::Mode::Append (BP4 only)
      * @return engine object
      */

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -59,6 +59,7 @@ enum class Mode
     Write,
     Read,
     Append,
+    ReadRandomAccess, // reader random access mode
     // launch execution modes
     Sync,
     Deferred
@@ -88,7 +89,7 @@ enum class StepMode
 {
     Append,
     Update, // writer advance mode
-    Read    // reader advance mode
+    Read,   // reader advance mode
 };
 
 enum class StepStatus

--- a/source/adios2/core/CoreTypes.h
+++ b/source/adios2/core/CoreTypes.h
@@ -1,0 +1,38 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * CoreTypes.h : types used only in the core framework, in contrast to
+ *               ADIOSTypes.h, which is a public user-facing header
+ *
+ *  Created on: Aug 11, 2021
+ *      Author:  Norbert Podhorszki pnorbert@ornl.gov
+ */
+
+#ifndef ADIOS2_CORETYPES_H_
+#define ADIOS2_CORETYPES_H_
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <cstddef>
+#include <cstdint>
+/// \endcond
+
+#include "adios2/common/ADIOSConfig.h"
+
+namespace adios2
+{
+namespace core
+{
+
+struct iovec
+{
+    //  Base address of a memory region for input or output.
+    const void *iov_base;
+    //  The size of the memory pointed to by iov_base.
+    size_t iov_len;
+};
+
+} // end namespace core
+} // end namespace adios2
+
+#endif /* ADIOS2_CORETYPES_H_ */

--- a/source/adios2/core/CoreTypes.h
+++ b/source/adios2/core/CoreTypes.h
@@ -13,6 +13,7 @@
 #define ADIOS2_CORETYPES_H_
 
 /// \cond EXCLUDE_FROM_DOXYGEN
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 /// \endcond
@@ -31,6 +32,14 @@ struct iovec
     //  The size of the memory pointed to by iov_base.
     size_t iov_len;
 };
+
+typedef std::chrono::duration<double> Seconds;
+typedef std::chrono::time_point<
+    std::chrono::steady_clock,
+    std::chrono::duration<double, std::chrono::steady_clock::period>>
+    TimePoint;
+
+inline TimePoint Now() { return std::chrono::steady_clock::now(); }
 
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -86,7 +86,8 @@ void Engine::Put(const std::string &variableName, const T &datum,
 template <class T>
 void Engine::Get(Variable<T> &variable, T *data, const Mode launch)
 {
-    CommonChecks(variable, data, {{Mode::Read}}, "in call to Get");
+    CommonChecks(variable, data, {{Mode::Read}, {Mode::ReadRandomAccess}},
+                 "in call to Get");
 
     switch (launch)
     {

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -514,6 +514,8 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     auto itEngineFound = m_Engines.find(name);
     const bool isEngineFound = (itEngineFound != m_Engines.end());
     bool isEngineActive = false;
+    Mode mode_to_use = mode;
+
     if (isEngineFound)
     {
         if (*itEngineFound->second)
@@ -560,7 +562,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         {
             engineTypeLC = "hdf5";
         }
-        else if (mode == Mode::Read)
+        else if (mode_to_use == Mode::Read)
         {
             if (adios2sys::SystemTools::FileIsDirectory(name))
             {
@@ -621,18 +623,23 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         //          << std::endl;
     }
 
+    if ((engineTypeLC != "bp5") && (mode_to_use == Mode::ReadRandomAccess))
+    {
+        // only BP5 special-cases file-reader random access mode
+        mode_to_use = Mode::Read;
+    }
     // For the inline engine, there must be exactly 1 reader, and exactly 1
     // writer.
     if (engineTypeLC == "inline")
     {
-        if (mode == Mode::Append)
+        if (mode_to_use == Mode::Append)
         {
             throw std::runtime_error(
                 "Append mode is not supported for the inline engine.");
         }
 
         // See inline.rst:44
-        if (mode == Mode::Sync)
+        if (mode_to_use == Mode::Sync)
         {
             throw std::runtime_error(
                 "Sync mode is not supported for the inline engine.");
@@ -653,7 +660,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         if (m_Engines.size() == 1)
         {
             auto engine_ptr = m_Engines.begin()->second;
-            if (engine_ptr->OpenMode() == mode)
+            if (engine_ptr->OpenMode() == mode_to_use)
             {
                 std::string msg =
                     "The previously added engine " + engine_ptr->m_Name +
@@ -669,13 +676,16 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     auto f = FactoryLookup(engineTypeLC);
     if (f != Factory.end())
     {
-        if (mode == Mode::Read)
+        if ((mode_to_use == Mode::Read) ||
+            (mode_to_use == Mode::ReadRandomAccess))
         {
-            engine = f->second.MakeReader(*this, name, mode, std::move(comm));
+            engine =
+                f->second.MakeReader(*this, name, mode_to_use, std::move(comm));
         }
         else
         {
-            engine = f->second.MakeWriter(*this, name, mode, std::move(comm));
+            engine =
+                f->second.MakeWriter(*this, name, mode_to_use, std::move(comm));
         }
     }
     else

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -120,7 +120,7 @@ public:
     using Span = core::Span<T>;
 
     /** Needs a map to preserve iterator as it resizes and the key to match the
-     * m_BlocksInfo index */
+     * m_BlocksInfo index (BP4 ONLY) */
     std::map<size_t, Span> m_BlocksSpan;
 
     Variable<T>(const std::string &name, const Dims &shape, const Dims &start,

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -156,18 +156,17 @@ void BP4Reader::Init()
 
     /* Do a collective wait for the file(s) to appear within timeout.
        Make sure every process comes to the same conclusion */
-    const Seconds timeoutSeconds =
-        Seconds(m_BP4Deserializer.m_Parameters.OpenTimeoutSecs);
+    const Seconds timeoutSeconds(
+        m_BP4Deserializer.m_Parameters.OpenTimeoutSecs);
 
-    Seconds pollSeconds =
-        Seconds(m_BP4Deserializer.m_Parameters.BeginStepPollingFrequencySecs);
+    Seconds pollSeconds(
+        m_BP4Deserializer.m_Parameters.BeginStepPollingFrequencySecs);
     if (pollSeconds > timeoutSeconds)
     {
         pollSeconds = timeoutSeconds;
     }
 
-    TimePoint timeoutInstant =
-        std::chrono::steady_clock::now() + timeoutSeconds;
+    TimePoint timeoutInstant = Now() + timeoutSeconds;
 
     OpenFiles(timeoutInstant, pollSeconds, timeoutSeconds);
     if (!m_BP4Deserializer.m_Parameters.StreamReader)
@@ -180,7 +179,7 @@ void BP4Reader::Init()
 bool BP4Reader::SleepOrQuit(const TimePoint &timeoutInstant,
                             const Seconds &pollSeconds)
 {
-    auto now = std::chrono::steady_clock::now();
+    auto now = Now();
     if (now + pollSeconds >= timeoutInstant)
     {
         return false;
@@ -684,8 +683,7 @@ StepStatus BP4Reader::CheckForNewSteps(Seconds timeoutSeconds)
     {
         timeoutSeconds = Seconds(999999999); // max 1 billion seconds wait
     }
-    const TimePoint timeoutInstant =
-        std::chrono::steady_clock::now() + timeoutSeconds;
+    const TimePoint timeoutInstant = Now() + timeoutSeconds;
 
     auto pollSeconds =
         Seconds(m_BP4Deserializer.m_Parameters.BeginStepPollingFrequencySecs);

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -12,12 +12,11 @@
 #define ADIOS2_ENGINE_BP4_BP4READER_H_
 
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/core/Engine.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/toolkit/format/bp/bp4/BP4Deserializer.h"
 #include "adios2/toolkit/transportman/TransportMan.h"
-
-#include <chrono>
 
 namespace adios2
 {
@@ -52,12 +51,6 @@ public:
     void PerformGets() final;
 
 private:
-    typedef std::chrono::duration<double> Seconds;
-    typedef std::chrono::time_point<
-        std::chrono::steady_clock,
-        std::chrono::duration<double, std::chrono::steady_clock::period>>
-        TimePoint;
-
     format::BP4Deserializer m_BP4Deserializer;
     /* transport manager for metadata file */
     transportman::TransportMan m_MDFileManager;

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -11,7 +11,6 @@
 
 #include <adios2-perfstubs-interface.h>
 
-#include <chrono>
 #include <errno.h>
 
 namespace adios2
@@ -224,8 +223,7 @@ void BP5Reader::Init()
         pollSeconds = timeoutSeconds;
     }
 
-    TimePoint timeoutInstant =
-        std::chrono::steady_clock::now() + timeoutSeconds;
+    TimePoint timeoutInstant = Now() + timeoutSeconds;
 
     OpenFiles(timeoutInstant, pollSeconds, timeoutSeconds);
 
@@ -236,7 +234,7 @@ void BP5Reader::Init()
 bool BP5Reader::SleepOrQuit(const TimePoint &timeoutInstant,
                             const Seconds &pollSeconds)
 {
-    auto now = std::chrono::steady_clock::now();
+    auto now = Now();
     if (now + pollSeconds >= timeoutInstant)
     {
         return false;

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -12,6 +12,7 @@
 #define ADIOS2_ENGINE_BP5_BP5READER_H_
 
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/core/Engine.h"
 #include "adios2/engine/bp5/BP5Engine.h"
 #include "adios2/helper/adiosComm.h"
@@ -55,12 +56,6 @@ public:
     MinVarInfo *MinBlocksInfo(const VariableBase &, const size_t Step) const;
 
 private:
-    typedef std::chrono::duration<double> Seconds;
-    typedef std::chrono::time_point<
-        std::chrono::steady_clock,
-        std::chrono::duration<double, std::chrono::steady_clock::period>>
-        TimePoint;
-
     format::BP5Deserializer *m_BP5Deserializer = nullptr;
     /* transport manager for metadata file */
     transportman::TransportMan m_MDFileManager;

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -194,6 +194,7 @@ private:
     uint64_t MetadataExpectedMinFileSize(const std::string &IdxFileName,
                                          bool hasHeader);
     void InstallMetaMetaData(format::BufferSTL MetaMetadata);
+    void InstallMetadataForTimestep(size_t Step);
     void ReadData(const size_t WriterRank, const size_t Timestep,
                   const size_t StartOffset, const size_t Length,
                   char *Destination);

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -10,6 +10,7 @@
 #define ADIOS2_ENGINE_BP5_BP5WRITER_H_
 
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/core/Engine.h"
 #include "adios2/engine/bp5/BP5Engine.h"
 #include "adios2/helper/adiosComm.h"
@@ -145,9 +146,8 @@ private:
 
     void WriteMetadataFileIndex(uint64_t MetaDataPos, uint64_t MetaDataSize);
 
-    uint64_t
-    WriteMetadata(const std::vector<format::BufferV::iovec> MetaDataBlocks,
-                  const std::vector<format::BufferV::iovec> AttributeBlocks);
+    uint64_t WriteMetadata(const std::vector<core::iovec> &MetaDataBlocks,
+                           const std::vector<core::iovec> &AttributeBlocks);
 
     /** Write Data to disk, in an aggregator chain */
     void WriteData(format::BufferV *Data);
@@ -168,9 +168,8 @@ private:
     void MarshalAttributes();
 
     /* Two-level-shm aggregator functions */
-    void WriteMyOwnData(format::BufferV::BufferV_iovec DataVec);
-    void SendDataToAggregator(format::BufferV::BufferV_iovec DataVec,
-                              const size_t TotalSize);
+    void WriteMyOwnData(format::BufferV *Data);
+    void SendDataToAggregator(format::BufferV *Data);
     void WriteOthersData(const size_t TotalSize);
 
     template <class T>

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -66,7 +66,7 @@ private:
 
     transportman::TransportMan m_FileMetaMetadataManager;
 
-    int64_t m_WriterStep = -1;
+    int64_t m_WriterStep = 0;
     /*
      *  Burst buffer variables
      */
@@ -93,6 +93,8 @@ private:
     std::vector<std::string> m_MetadataIndexFileNames;
     std::vector<std::string> m_DrainMetadataIndexFileNames;
     std::vector<std::string> m_ActiveFlagFileNames;
+
+    bool m_BetweenStepPairs = false;
 
     void Init() final;
 

--- a/source/adios2/engine/bp5/BP5Writer.tcc
+++ b/source/adios2/engine/bp5/BP5Writer.tcc
@@ -21,6 +21,10 @@ namespace engine
 template <class T>
 void BP5Writer::PutCommon(Variable<T> &variable, const T *values, bool sync)
 {
+    if (!m_BetweenStepPairs)
+    {
+        BeginStep(StepMode::Update);
+    }
     variable.SetData(values);
 
     size_t *Shape = NULL;
@@ -99,6 +103,10 @@ void BP5Writer::PutCommonSpan(Variable<T> &variable,
     size_t *Count = NULL;
     size_t DimCount = 0;
 
+    if (!m_BetweenStepPairs)
+    {
+        BeginStep(StepMode::Update);
+    }
     if (variable.m_ShapeID == ShapeID::GlobalArray)
     {
         DimCount = variable.m_Shape.size();

--- a/source/adios2/engine/mhs/MhsReader.cpp
+++ b/source/adios2/engine/mhs/MhsReader.cpp
@@ -27,6 +27,7 @@ MhsReader::MhsReader(IO &io, const std::string &name, const Mode mode,
     io.SetEngine("");
     m_SubIOs.emplace_back(&io);
     m_SubEngines.emplace_back(&io.Open(m_Name + ".tier0", adios2::Mode::Read));
+
     for (int i = 1; i < m_Tiers; ++i)
     {
         m_SubIOs.emplace_back(

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -293,11 +293,18 @@ void SstWriter::EndStep()
         newblock->MetaMetaBlocks = MetaMetaBlocks;
         newblock->metadata.DataSize = TSInfo->MetaEncodeBuffer->m_FixedSize;
         newblock->metadata.block = TSInfo->MetaEncodeBuffer->Data();
-        format::BufferV::BufferV_iovec iovec = TSInfo->DataBuffer->DataVec();
-        newblock->data.DataSize = iovec[0].iov_len;
-        newblock->data.block = (char *)iovec[0].iov_base;
+        std::vector<core::iovec> iovec = TSInfo->DataBuffer->DataVec();
+        if (!iovec.empty())
+        {
+            newblock->data.DataSize = iovec[0].iov_len;
+            newblock->data.block = (char *)iovec[0].iov_base;
+        }
+        else
+        {
+            newblock->data.DataSize = 0;
+            newblock->data.block = nullptr;
+        }
         newblock->TSInfo = TSInfo;
-        delete[] iovec;
         if (TSInfo->AttributeEncodeBuffer)
         {
             newblock->attribute_data.DataSize =

--- a/source/adios2/toolkit/format/bp5/BP5Base.h
+++ b/source/adios2/toolkit/format/bp5/BP5Base.h
@@ -37,13 +37,13 @@ public:
 
     typedef struct _MetaArrayRec
     {
-        size_t Dims;       // How many dimensions does this array have
-        size_t BlockCount; // How many blocks are written
-        size_t DBCount;    // Dimens * BlockCount
-        size_t *Shape;     // Global dimensionality  [Dims]	NULL for local
-        size_t *Count;     // Per-block Counts	  [DBCount]
-        size_t *Offsets;   // Per-block Offsets	  [DBCount]	NULL for local
-        size_t *DataLocation;
+        size_t Dims;          // How many dimensions does this array have
+        size_t BlockCount;    // How many blocks are written
+        size_t DBCount;       // Dimens * BlockCount
+        size_t *Shape;        // Global dimensionality  [Dims]	NULL for local
+        size_t *Count;        // Per-block Counts	  [DBCount]
+        size_t *Offsets;      // Per-block Offsets	  [DBCount]	NULL for local
+        size_t *DataLocation; // Per-block Offsets [BlockCount]
     } MetaArrayRec;
 
     struct FFSMetadataInfoStruct

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1053,7 +1053,9 @@ Engine::MinVarInfo *BP5Deserializer::MinBlocksInfo(const VariableBase &Var,
             (MetaArrayRec *)(((char *)MetadataBaseAddrs[WriterRank]) +
                              VarRec->PerWriterMetaFieldOffset[WriterRank]);
         size_t WriterBlockCount =
-            meta_base->Dims ? meta_base->DBCount / meta_base->Dims : 1;
+            writer_meta_base->Dims
+                ? writer_meta_base->DBCount / writer_meta_base->Dims
+                : 1;
         Id += WriterBlockCount;
     }
     MV->BlocksInfo.reserve(Id);

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -9,6 +9,7 @@
 #include "adios2/core/Attribute.h"
 #include "adios2/core/Engine.h"
 #include "adios2/core/IO.h"
+#include "adios2/core/VariableBase.h"
 
 #include "BP5Deserializer.h"
 #include "BP5Deserializer.tcc"
@@ -120,6 +121,11 @@ DataType BP5Deserializer::TranslateFFSType2ADIOS(const char *Type, int size)
     {
         return DataType::DoubleComplex;
     }
+    else if (strcmp(Type, "string") == 0)
+    {
+        return DataType::String;
+    }
+
     return DataType::None;
 }
 
@@ -162,10 +168,16 @@ BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByName(const char *Name)
 
 BP5Deserializer::BP5VarRec *BP5Deserializer::CreateVarRec(const char *ArrayName)
 {
-    BP5VarRec *Ret = new BP5VarRec(m_WriterCohortSize);
+    BP5VarRec *Ret = new BP5VarRec();
     Ret->VarName = strdup(ArrayName);
     Ret->Variable = nullptr;
+    Ret->VarNum = m_VarCount++;
     VarByName[Ret->VarName] = Ret;
+    if (!m_RandomAccessMode)
+    {
+        Ret->PerWriterMetaFieldOffset.resize(m_WriterCohortSize);
+        Ret->PerWriterBlockStart.resize(m_WriterCohortSize);
+    }
     return Ret;
 }
 
@@ -182,6 +194,7 @@ BP5Deserializer::ControlInfo *BP5Deserializer::BuildControl(FMFormat Format)
     int ControlCount = 0;
     ControlInfo *ret = (BP5Deserializer::ControlInfo *)malloc(sizeof(*ret));
     ret->Format = Format;
+    ret->MetaFieldOffset = new std::vector<size_t>();
     while (FieldList[i].field_name)
     {
         ret = (ControlInfo *)realloc(
@@ -189,22 +202,18 @@ BP5Deserializer::ControlInfo *BP5Deserializer::BuildControl(FMFormat Format)
         struct ControlStruct *C = &(ret->Controls[ControlCount]);
         ControlCount++;
 
-        C->FieldIndex = i;
         C->FieldOffset = FieldList[i].field_offset;
 
+        BP5VarRec *VarRec = nullptr;
         if (NameIndicatesArray(FieldList[i].field_name))
         {
             char *ArrayName;
             DataType Type;
-            BP5VarRec *VarRec = nullptr;
             int ElementSize;
             C->IsArray = 1;
             BreakdownArrayName(FieldList[i].field_name, &ArrayName, &Type,
                                &ElementSize);
-            //            if (WriterRank != 0)
-            //            {
             VarRec = LookupVarByName(ArrayName);
-            //            }
             if (!VarRec)
             {
                 VarRec = CreateVarRec(ArrayName);
@@ -220,7 +229,6 @@ BP5Deserializer::ControlInfo *BP5Deserializer::BuildControl(FMFormat Format)
         {
             /* simple field */
             char *FieldName = strdup(FieldList[i].field_name + 4); // skip SST_
-            BP5VarRec *VarRec = NULL;
             C->IsArray = 0;
             VarRec = LookupVarByName(FieldName);
             if (!VarRec)
@@ -238,6 +246,9 @@ BP5Deserializer::ControlInfo *BP5Deserializer::BuildControl(FMFormat Format)
             free(FieldName);
             i++;
         }
+        if (ret->MetaFieldOffset->size() <= VarRec->VarNum)
+            ret->MetaFieldOffset->resize(VarRec->VarNum + 1);
+        (*ret->MetaFieldOffset)[VarRec->VarNum] = C->FieldOffset;
     }
     ret->ControlCount = ControlCount;
     ret->Next = ControlBlocks;
@@ -332,8 +343,10 @@ void BP5Deserializer::SetupForTimestep(size_t Timestep)
 {
     CurTimestep = Timestep;
     PendingRequests.clear();
+
     for (auto RecPair : VarByKey)
     {
+        m_Engine->m_IO.RemoveVariable(RecPair.second->VarName);
         RecPair.second->Variable = NULL;
     }
 }
@@ -379,31 +392,58 @@ void BP5Deserializer::InstallMetaData(void *MetadataBlock, size_t BlockLen,
         printf("\n\n");
     }
     struct ControlInfo *Control;
-    struct ControlStruct *ControlArray;
+    struct ControlStruct *ControlFields;
     Control = GetPriorControl(FMFormat_of_original(FFSformat));
     if (!Control)
     {
         Control = BuildControl(FMFormat_of_original(FFSformat));
     }
-    ControlArray = &Control->Controls[0];
+    ControlFields = &Control->Controls[0];
 
-    //    if (m_RandomAccessMode) {
-    //	PrepareForTimestep(Step);
-    //    }
-    MetadataBaseAddrs[WriterRank] = BaseData;
-    //    } else {
-    //	Loaded
+    if (m_RandomAccessMode)
+    {
+        if (m_ControlArray.size() < Step + 1)
+        {
+            m_ControlArray.resize(Step + 1);
+        }
+        if (m_ControlArray[Step].size() == 0)
+        {
+            m_ControlArray[Step].resize(m_WriterCohortSize);
+        }
+        m_ControlArray[Step][WriterRank] = Control;
+
+        MetadataBaseArray.resize(Step + 1);
+        if (MetadataBaseArray[Step] == nullptr)
+        {
+            m_MetadataBaseAddrs = new std::vector<void *>();
+            m_MetadataBaseAddrs->resize(m_WriterCohortSize);
+            MetadataBaseArray[Step] = m_MetadataBaseAddrs;
+            m_FreeableMBA = nullptr;
+        }
+    }
+    else
+    {
+        if (!m_MetadataBaseAddrs)
+        {
+            m_MetadataBaseAddrs = new std::vector<void *>();
+            m_FreeableMBA = m_MetadataBaseAddrs;
+            m_MetadataBaseAddrs->resize(m_WriterCohortSize);
+        }
+    }
+    (*m_MetadataBaseAddrs)[WriterRank] = BaseData;
+
     for (int i = 0; i < Control->ControlCount; i++)
     {
-        int FieldOffset = ControlArray[i].FieldOffset;
-        BP5VarRec *VarRec = ControlArray[i].VarRec;
+        size_t FieldOffset = ControlFields[i].FieldOffset;
+        BP5VarRec *VarRec = ControlFields[i].VarRec;
         void *field_data = (char *)BaseData + FieldOffset;
         if (!FFSBitfieldTest((FFSMetadataInfoStruct *)BaseData, i))
         {
             continue;
         }
-        VarRec->PerWriterMetaFieldOffset[WriterRank] = FieldOffset;
-        if (ControlArray[i].IsArray)
+        if (!m_RandomAccessMode)
+            VarRec->PerWriterMetaFieldOffset[WriterRank] = FieldOffset;
+        if (ControlFields[i].IsArray)
         {
             MetaArrayRec *meta_base = (MetaArrayRec *)field_data;
             if ((meta_base->Dims > 1) &&
@@ -415,14 +455,9 @@ void BP5Deserializer::InstallMetaData(void *MetadataBlock, size_t BlockLen,
                 ReverseDimensions(meta_base->Count, meta_base->Dims);
                 ReverseDimensions(meta_base->Offsets, meta_base->Dims);
             }
-            if (WriterRank == 0)
+            if ((WriterRank == 0) || (VarRec->GlobalDims == NULL))
             {
-                // use the shape from rank 0
-                VarRec->GlobalDims = meta_base->Shape;
-            }
-            else if (VarRec->GlobalDims == NULL)
-            {
-                // unless there wasn't one before
+                // use the shape from rank 0 (or first non-NULL)
                 VarRec->GlobalDims = meta_base->Shape;
             }
             if (!VarRec->Variable)
@@ -431,21 +466,26 @@ void BP5Deserializer::InstallMetaData(void *MetadataBlock, size_t BlockLen,
                     m_Engine, VarRec->VarName, VarRec->Type, meta_base->Dims,
                     meta_base->Shape, meta_base->Offsets, meta_base->Count);
                 VarByKey[VarRec->Variable] = VarRec;
+                VarRec->LastTSAdded = Step; // starts at 1
             }
+
             VarRec->DimCount = meta_base->Dims;
             size_t BlockCount =
                 meta_base->Dims ? meta_base->DBCount / meta_base->Dims : 1;
-            VarRec->PerWriterDataLocation[WriterRank] = meta_base->DataLocation;
-            if (WriterRank == 0)
+            if (!m_RandomAccessMode)
             {
-                VarRec->PerWriterBlockStart[WriterRank] = 0;
-                if (m_WriterCohortSize > 1)
-                    VarRec->PerWriterBlockStart[WriterRank + 1] = BlockCount;
-            }
-            if (WriterRank < static_cast<size_t>(m_WriterCohortSize - 1))
-            {
-                VarRec->PerWriterBlockStart[WriterRank + 1] =
-                    VarRec->PerWriterBlockStart[WriterRank] + BlockCount;
+                if (WriterRank == 0)
+                {
+                    VarRec->PerWriterBlockStart[WriterRank] = 0;
+                    if (m_WriterCohortSize > 1)
+                        VarRec->PerWriterBlockStart[WriterRank + 1] =
+                            BlockCount;
+                }
+                if (WriterRank < static_cast<size_t>(m_WriterCohortSize - 1))
+                {
+                    VarRec->PerWriterBlockStart[WriterRank + 1] =
+                        VarRec->PerWriterBlockStart[WriterRank] + BlockCount;
+                }
             }
         }
         else
@@ -455,7 +495,14 @@ void BP5Deserializer::InstallMetaData(void *MetadataBlock, size_t BlockLen,
                 VarRec->Variable = VarSetup(m_Engine, VarRec->VarName,
                                             VarRec->Type, field_data);
                 VarByKey[VarRec->Variable] = VarRec;
+                VarRec->LastTSAdded = Step; // starts at 1
             }
+        }
+        if (m_RandomAccessMode && (VarRec->LastTSAdded != Step))
+        {
+            static_cast<VariableBase *>(VarRec->Variable)
+                ->m_AvailableStepsCount++;
+            VarRec->LastTSAdded = Step;
         }
     }
 }
@@ -550,16 +597,73 @@ void BP5Deserializer::InstallAttributeData(void *AttributeBlock,
 
 bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData)
 {
+    if (!m_RandomAccessMode)
+    {
+        return QueueGetSingle(variable, DestData, CurTimestep);
+    }
+    else
+    {
+        bool ret = false;
+        if (variable.m_StepsStart + variable.m_StepsCount >
+            variable.m_AvailableStepsCount)
+        {
+            throw std::invalid_argument(
+                "ERROR: offset " + std::to_string(variable.m_StepsCount) +
+                " from steps start " + std::to_string(variable.m_StepsStart) +
+                " in variable " + variable.m_Name +
+                " is beyond the largest available step = " +
+                std::to_string(variable.m_AvailableStepsCount +
+                               variable.m_AvailableStepsStart) +
+                ", check Variable SetStepSelection argument stepsCount "
+                "(random access), or "
+                "number of BeginStep calls (streaming), in call to Get");
+        }
+        for (size_t i = 0; i < variable.m_StepsCount; i++)
+        {
+            ret = QueueGetSingle(variable, DestData, variable.m_StepsStart + i);
+            size_t increment = variable.TotalSize() * variable.m_ElementSize;
+            DestData = (void *)((char *)DestData + increment);
+        }
+        return ret;
+    }
+}
+
+bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable,
+                                     void *DestData, size_t Step)
+{
     if (variable.m_SingleValue)
     {
+        char *src;
+        BP5VarRec *VarRec = VarByKey[&variable];
         int WriterRank = 0;
+        if (m_RandomAccessMode)
+        {
+            ControlInfo *CI =
+                m_ControlArray[Step][WriterRank]; // writer 0 control array
+            size_t MetadataFieldOffset = (*CI->MetaFieldOffset)[VarRec->VarNum];
+            char *MetadataBase =
+                (char *)((*MetadataBaseArray[Step])[WriterRank]);
+            src = MetadataBase + MetadataFieldOffset;
+        }
+        else
+        {
+            src = ((char *)(*m_MetadataBaseAddrs)[WriterRank]) +
+                  VarRec->PerWriterMetaFieldOffset[WriterRank];
+        }
         if (variable.m_SelectionType == adios2::SelectionType::WriteBlock)
             WriterRank = variable.m_BlockID;
 
-        BP5VarRec *VarRec = VarByKey[&variable];
-        char *src = ((char *)MetadataBaseAddrs[WriterRank]) +
-                    VarRec->PerWriterMetaFieldOffset[WriterRank];
-        memcpy(DestData, src, variable.m_ElementSize);
+        if (variable.m_Type != DataType::String)
+        {
+            std::cout << "Performing get for var " << variable.m_Name << " TS "
+                      << Step << "   Mdatabase " << (void *)src << std::endl;
+            memcpy(DestData, src, variable.m_ElementSize);
+        }
+        else
+        {
+            std::string *TmpStr = static_cast<std::string *>(DestData);
+            TmpStr->assign(*(const char **)src);
+        }
         return false;
     }
     if (variable.m_SelectionType == adios2::SelectionType::BoundingBox)
@@ -570,6 +674,7 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData)
         Req.BlockID = variable.m_BlockID;
         Req.Count = variable.m_Count;
         Req.Start = variable.m_Start;
+        Req.Step = Step;
         Req.Data = DestData;
         PendingRequests.push_back(Req);
     }
@@ -581,6 +686,7 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData)
         Req.BlockID = variable.m_BlockID;
         Req.Count = variable.m_Count;
         Req.Data = DestData;
+        Req.Step = Step;
         PendingRequests.push_back(Req);
     }
     else
@@ -591,9 +697,23 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData)
 
 bool BP5Deserializer::NeedWriter(BP5ArrayRequest Req, size_t WriterRank)
 {
-    MetaArrayRec *writer_meta_base =
-        (MetaArrayRec *)(((char *)MetadataBaseAddrs[WriterRank]) +
-                         Req.VarRec->PerWriterMetaFieldOffset[WriterRank]);
+    MetaArrayRec *writer_meta_base;
+    if (m_RandomAccessMode)
+    {
+        ControlInfo *CI =
+            m_ControlArray[Req.Step][WriterRank]; // writer 0 control array
+        size_t MetadataFieldOffset = (*CI->MetaFieldOffset)[Req.VarRec->VarNum];
+        writer_meta_base =
+            (MetaArrayRec
+                 *)(((char *)(*MetadataBaseArray[Req.Step])[WriterRank]) +
+                    MetadataFieldOffset);
+    }
+    else
+    {
+        writer_meta_base =
+            (MetaArrayRec *)(((char *)(*m_MetadataBaseAddrs)[WriterRank]) +
+                             Req.VarRec->PerWriterMetaFieldOffset[WriterRank]);
+    }
 
     if (Req.RequestType == Local)
     {
@@ -638,38 +758,43 @@ std::vector<BP5Deserializer::ReadRequest>
 BP5Deserializer::GenerateReadRequests()
 {
     std::vector<BP5Deserializer::ReadRequest> Ret;
-    for (auto &W : WriterInfo)
-    {
-        W.Status = Empty;
-        W.RawBuffer = NULL;
-    }
+    std::vector<FFSReaderPerWriterRec> WriterInfo(m_WriterCohortSize);
+    typedef std::pair<size_t, size_t> pair;
+    std::map<pair, bool> WriterTSNeeded;
 
     for (const auto &Req : PendingRequests)
     {
         for (size_t i = 0; i < m_WriterCohortSize; i++)
         {
-            if ((WriterInfo[i].Status != Needed) && (NeedWriter(Req, i)))
+            if (WriterTSNeeded.count(std::make_pair(Req.Step, i)) == 0)
             {
-                WriterInfo[i].Status = Needed;
+                WriterTSNeeded[std::make_pair(Req.Step, i)] = true;
             }
         }
     }
 
-    for (size_t i = 0; i < m_WriterCohortSize; i++)
+    for (std::pair<pair, bool> element : WriterTSNeeded)
     {
-        if (WriterInfo[i].Status == Needed)
+        ReadRequest RR;
+        RR.Timestep = element.first.first;
+        RR.WriterRank = element.first.second;
+        RR.StartOffset = 0;
+        if (m_RandomAccessMode)
         {
-            ReadRequest RR;
-            RR.Timestep = CurTimestep;
-            RR.WriterRank = i;
-            RR.StartOffset = 0;
             RR.ReadLength =
-                ((struct FFSMetadataInfoStruct *)MetadataBaseAddrs[i])
+                ((struct FFSMetadataInfoStruct *)((
+                     *MetadataBaseArray[RR.Timestep])[RR.WriterRank]))
                     ->DataBlockSize;
-            RR.DestinationAddr = (char *)malloc(RR.ReadLength);
-            RR.Internal = NULL;
-            Ret.push_back(RR);
         }
+        else
+        {
+            RR.ReadLength = ((struct FFSMetadataInfoStruct
+                                  *)(*m_MetadataBaseAddrs)[RR.WriterRank])
+                                ->DataBlockSize;
+        }
+        RR.DestinationAddr = (char *)malloc(RR.ReadLength);
+        RR.Internal = NULL;
+        Ret.push_back(RR);
     }
     return Ret;
 }
@@ -687,10 +812,27 @@ void BP5Deserializer::FinalizeGets(std::vector<ReadRequest> Requests)
                 /* if needed this writer fill destination with acquired data */
                 int ElementSize = Req.VarRec->ElementSize;
                 size_t *GlobalDimensions = Req.VarRec->GlobalDims;
-                MetaArrayRec *writer_meta_base =
-                    (MetaArrayRec
-                         *)(((char *)MetadataBaseAddrs[WriterRank]) +
-                            Req.VarRec->PerWriterMetaFieldOffset[WriterRank]);
+                MetaArrayRec *writer_meta_base;
+                if (m_RandomAccessMode)
+                {
+                    ControlInfo *CI =
+                        m_ControlArray[Req.Step]
+                                      [WriterRank]; // writer 0 control array
+                    size_t MetadataFieldOffset =
+                        (*CI->MetaFieldOffset)[Req.VarRec->VarNum];
+                    writer_meta_base =
+                        (MetaArrayRec *)(((char *)(*MetadataBaseArray[Req.Step])
+                                              [WriterRank]) +
+                                         MetadataFieldOffset);
+                }
+                else
+                {
+                    writer_meta_base =
+                        (MetaArrayRec
+                             *)(((char *)(*m_MetadataBaseAddrs)[WriterRank]) +
+                                Req.VarRec
+                                    ->PerWriterMetaFieldOffset[WriterRank]);
+                }
                 int DimCount = writer_meta_base->Dims;
                 size_t *RankOffset = writer_meta_base->Offsets;
                 const size_t *RankSize = writer_meta_base->Count;
@@ -701,16 +843,17 @@ void BP5Deserializer::FinalizeGets(std::vector<ReadRequest> Requests)
                 const size_t *SelSize = Req.Count.data();
                 int ReqIndex = 0;
                 while (Requests[ReqIndex].WriterRank !=
-                       static_cast<size_t>(WriterRank))
+                           static_cast<size_t>(WriterRank) ||
+                       (Requests[ReqIndex].Timestep != Req.Step))
                     ReqIndex++;
-                if (Req.VarRec->PerWriterDataLocation[WriterRank] == NULL)
+                if (writer_meta_base->DataLocation == NULL)
                 {
                     // No Data from this writer
                     continue;
                 }
                 char *IncomingData =
                     (char *)Requests[ReqIndex].DestinationAddr +
-                    Req.VarRec->PerWriterDataLocation[WriterRank][0];
+                    writer_meta_base->DataLocation[0];
                 if (Req.Start.size())
                 {
                     SelOffset = Req.Start.data();
@@ -720,10 +863,8 @@ void BP5Deserializer::FinalizeGets(std::vector<ReadRequest> Requests)
                     int LocalBlockID =
                         Req.BlockID -
                         Req.VarRec->PerWriterBlockStart[WriterRank];
-                    IncomingData =
-                        (char *)Requests[ReqIndex].DestinationAddr +
-                        Req.VarRec
-                            ->PerWriterDataLocation[WriterRank][LocalBlockID];
+                    IncomingData = (char *)Requests[ReqIndex].DestinationAddr +
+                                   writer_meta_base->DataLocation[LocalBlockID];
 
                     RankOffset = ZeroRankOffset.data();
                     GlobalDimensions = ZeroGlobalDimensions.data();
@@ -997,30 +1138,25 @@ void BP5Deserializer::ExtractSelectionFromPartialCM(
 }
 
 BP5Deserializer::BP5Deserializer(int WriterCount, bool WriterIsRowMajor,
-                                 bool ReaderIsRowMajor)
+                                 bool ReaderIsRowMajor, bool RandomAccessMode)
 : m_WriterIsRowMajor{WriterIsRowMajor}, m_ReaderIsRowMajor{ReaderIsRowMajor},
-  m_WriterCohortSize{static_cast<size_t>(WriterCount)}
+  m_WriterCohortSize{static_cast<size_t>(WriterCount)}, m_RandomAccessMode{
+                                                            RandomAccessMode}
 {
     FMContext Tmp = create_local_FMcontext();
     ReaderFFSContext = create_FFSContext_FM(Tmp);
     free_FMcontext(Tmp);
-    WriterInfo.resize(m_WriterCohortSize);
-    MetadataBaseAddrs.resize(m_WriterCohortSize);
 }
 
 BP5Deserializer::~BP5Deserializer()
 {
-    free_FFSContext(ReaderFFSContext);
-    for (size_t i = 0; i < m_WriterCohortSize; i++)
-    {
-        if (WriterInfo[i].RawBuffer)
-            free(WriterInfo[i].RawBuffer);
-    }
     struct ControlInfo *tmp = ControlBlocks;
+    free_FFSContext(ReaderFFSContext);
     ControlBlocks = NULL;
     while (tmp)
     {
         struct ControlInfo *next = tmp->Next;
+        delete tmp->MetaFieldOffset;
         free(tmp);
         tmp = next;
     }
@@ -1029,6 +1165,12 @@ BP5Deserializer::~BP5Deserializer()
         free(VarRec.second->VarName);
         delete VarRec.second;
     }
+    if (m_FreeableMBA)
+        delete m_FreeableMBA;
+    for (auto &step : MetadataBaseArray)
+    {
+        delete step;
+    }
 }
 
 Engine::MinVarInfo *BP5Deserializer::MinBlocksInfo(const VariableBase &Var,
@@ -1036,7 +1178,7 @@ Engine::MinVarInfo *BP5Deserializer::MinBlocksInfo(const VariableBase &Var,
 {
     BP5VarRec *VarRec = LookupVarByKey((void *)&Var);
     MetaArrayRec *meta_base =
-        (MetaArrayRec *)(((char *)MetadataBaseAddrs[0]) +
+        (MetaArrayRec *)(((char *)(*m_MetadataBaseAddrs)[0]) +
                          VarRec->PerWriterMetaFieldOffset[0]);
     Engine::MinVarInfo *MV =
         new Engine::MinVarInfo(meta_base->Dims, meta_base->Shape);
@@ -1050,7 +1192,7 @@ Engine::MinVarInfo *BP5Deserializer::MinBlocksInfo(const VariableBase &Var,
     for (size_t WriterRank = 0; WriterRank < m_WriterCohortSize; WriterRank++)
     {
         MetaArrayRec *writer_meta_base =
-            (MetaArrayRec *)(((char *)MetadataBaseAddrs[WriterRank]) +
+            (MetaArrayRec *)(((char *)(*m_MetadataBaseAddrs)[WriterRank]) +
                              VarRec->PerWriterMetaFieldOffset[WriterRank]);
         size_t WriterBlockCount =
             writer_meta_base->Dims
@@ -1064,7 +1206,7 @@ Engine::MinVarInfo *BP5Deserializer::MinBlocksInfo(const VariableBase &Var,
     for (size_t WriterRank = 0; WriterRank < m_WriterCohortSize; WriterRank++)
     {
         MetaArrayRec *writer_meta_base =
-            (MetaArrayRec *)(((char *)MetadataBaseAddrs[WriterRank]) +
+            (MetaArrayRec *)(((char *)(*m_MetadataBaseAddrs)[WriterRank]) +
                              VarRec->PerWriterMetaFieldOffset[WriterRank]);
 
         size_t WriterBlockCount =

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -47,10 +47,12 @@ public:
         char *DestinationAddr;
         void *Internal;
     };
+    void SetupForRandomAccess();
     void InstallMetaMetaData(MetaMetaInfoBlock &MMList);
     void InstallMetaData(void *MetadataBlock, size_t BlockLen,
-                         size_t WriterRank);
-    void InstallAttributeData(void *AttributeBlock, size_t BlockLen);
+                         size_t WriterRank, size_t Step = SIZE_MAX);
+    void InstallAttributeData(void *AttributeBlock, size_t BlockLen,
+                              size_t Step = SIZE_MAX);
     void SetupForTimestep(size_t t);
     // return from QueueGet is true if a sync is needed to fill the data
     bool QueueGet(core::VariableBase &variable, void *DestData);
@@ -64,6 +66,7 @@ public:
     bool m_WriterIsRowMajor = 1;
     bool m_ReaderIsRowMajor = 1;
     core::Engine *m_Engine = NULL;
+    bool m_RandomAccessMode = 0;
 
 private:
     struct BP5VarRec
@@ -74,23 +77,14 @@ private:
         DataType Type;
         int ElementSize = 0;
         size_t *GlobalDims = NULL;
+        size_t LastTSAdded = SIZE_MAX;
         std::vector<size_t> PerWriterMetaFieldOffset;
         std::vector<size_t> PerWriterBlockStart;
-        std::vector<size_t> PerWriterBlockCount;
-        std::vector<size_t *> PerWriterStart;
-        std::vector<size_t *> PerWriterCounts;
-        std::vector<void *> PerWriterIncomingData;
-        std::vector<size_t> PerWriterIncomingSize; // important for compression
         std::vector<size_t *> PerWriterDataLocation;
         BP5VarRec(int WriterSize)
         {
             PerWriterMetaFieldOffset.resize(WriterSize);
             PerWriterBlockStart.resize(WriterSize);
-            PerWriterBlockCount.resize(WriterSize);
-            PerWriterStart.resize(WriterSize);
-            PerWriterCounts.resize(WriterSize);
-            PerWriterIncomingData.resize(WriterSize);
-            PerWriterIncomingSize.resize(WriterSize);
             PerWriterDataLocation.resize(WriterSize);
         }
     };

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -47,7 +47,6 @@ public:
         char *DestinationAddr;
         void *Internal;
     };
-    void SetupForRandomAccess();
     void InstallMetaMetaData(MetaMetaInfoBlock &MMList);
     void InstallMetaData(void *MetadataBlock, size_t BlockLen,
                          size_t WriterRank, size_t Step = SIZE_MAX);
@@ -68,7 +67,6 @@ public:
     bool m_WriterIsRowMajor = 1;
     bool m_ReaderIsRowMajor = 1;
     core::Engine *m_Engine = NULL;
-    bool m_RandomAccessMode = true;
 
 private:
     size_t m_VarCount = 0;
@@ -119,6 +117,8 @@ private:
 
     FFSContext ReaderFFSContext;
     size_t m_WriterCohortSize;
+    bool m_RandomAccessMode;
+
     std::unordered_map<std::string, BP5VarRec *> VarByName;
     std::unordered_map<void *, BP5VarRec *> VarByKey;
 

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -871,15 +871,14 @@ std::vector<char> BP5Serializer::CopyMetadataToContiguous(
     return Ret;
 }
 
-std::vector<BufferV::iovec> BP5Serializer::BreakoutContiguousMetadata(
+std::vector<core::iovec> BP5Serializer::BreakoutContiguousMetadata(
     std::vector<char> *Aggregate, const std::vector<size_t> Counts,
     std::vector<MetaMetaInfoBlock> &UniqueMetaMetaBlocks,
-    std::vector<BufferV::iovec> &AttributeBlocks,
-    std::vector<uint64_t> &DataSizes,
+    std::vector<core::iovec> &AttributeBlocks, std::vector<uint64_t> &DataSizes,
     std::vector<uint64_t> &WriterDataPositions) const
 {
     size_t Position = 0;
-    std::vector<BufferV::iovec> MetadataBlocks;
+    std::vector<core::iovec> MetadataBlocks;
     MetadataBlocks.reserve(Counts.size());
     DataSizes.resize(Counts.size());
     for (size_t Rank = 0; Rank < Counts.size(); Rank++)

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -605,50 +605,29 @@ void BP5Serializer::MarshalAttribute(const char *Name, const DataType Type,
     }
     else
     {
-        /* // Array field.  To Metadata, add FMFields for DimCount, Shape, Count
-         */
-        /* // and Offsets matching _MetaArrayRec */
-        /* char *ArrayName = BuildStaticArrayName(Name, Type, ElemCount); */
-        /* AddField(&Info->AttributeFields, &Info->AttributeFieldCount,
-         * ArrayName, Type, */
-        /*          sizeof(size_t)); */
-        /* free(ArrayName); */
-        /* Rec->MetaOffset = */
-        /*     Info->MetaFields[Info->MetaFieldCount - 1].field_offset; */
-        /* char *ShapeName = ConcatName(Name, "Shape"); */
-        /* char *CountName = ConcatName(Name, "Count"); */
-        /* char *OffsetsName = ConcatName(Name, "Offsets"); */
-        /* AddFixedArrayField(&Info->MetaFields, &Info->MetaFieldCount,
-         * ShapeName, */
-        /*                    "integer", sizeof(size_t), DimCount); */
-        /* AddFixedArrayField(&Info->MetaFields, &Info->MetaFieldCount,
-         * CountName, */
-        /*                    "integer", sizeof(size_t), DimCount); */
-        /* AddFixedArrayField(&Info->MetaFields, &Info->MetaFieldCount, */
-        /*                    OffsetsName, "integer", sizeof(size_t), DimCount);
-         */
-        /* free(ShapeName); */
-        /* free(CountName); */
-        /* free(OffsetsName); */
-        /* RecalcMarshalStorageSize(Stream); */
-
-        /* // To Data, add FMFields for ElemCount and Array matching _ArrayRec
-         */
-        /* char *ElemCountName = ConcatName(Name, "ElemCount"); */
-        /* AddField(&Info->DataFields, &Info->DataFieldCount, ElemCountName, */
-        /*          "integer", sizeof(size_t)); */
-        /* Rec->DataOffset = */
-        /*     Info->DataFields[Info->DataFieldCount - 1].field_offset; */
-        /* char *SstName = ConcatName(Name, ""); */
-        /* AddVarArrayField(&Info->DataFields, &Info->DataFieldCount, SstName,
-         */
-        /*                  Type, ElemSize, ElemCountName); */
-        /* free(SstName); */
-        /* free(ElemCountName); */
-        /* RecalcMarshalStorageSize(Stream); */
-        /* // Changing the formats renders these invalid */
-        /* Info->MetaFormat = NULL; */
-        /* Info->DataFormat = NULL; */
+#ifdef NOTDEF
+        // Array field.  To Metadata, add FMFields for DimCount, Shape, Count
+        // and Offsets matching _MetaArrayRec
+        char *ArrayName = BuildArrayDimsName(Name, (int)Type, ElemCount);
+        AddField(&Info.AttributeFields, &Info.AttributeFieldCount, ArrayName,
+                 Type, sizeof(size_t));
+        free(ArrayName);
+        Rec->AttributeOffset =
+            Info.AttributeFields[Info.AttributeFieldCount - 1].field_offset;
+        char *ShapeName = ConcatName(Name, "Shape");
+        char *CountName = ConcatName(Name, "Count");
+        char *OffsetsName = ConcatName(Name, "Offsets");
+        AddFixedArrayField(&Info.AttributeFields, &Info.AttributeFieldCount,
+                           ShapeName, "integer", sizeof(size_t), DimCount);
+        AddFixedArrayField(&Info.AttributeFields, &Info.AttributeFieldCount,
+                           CountName, "integer", sizeof(size_t), DimCount);
+        AddFixedArrayField(&Info.AttributeFields, &Info.AttributeFieldCount,
+                           OffsetsName, "integer", sizeof(size_t), DimCount);
+        free(ShapeName);
+        free(CountName);
+        free(OffsetsName);
+        RecalcAttributeStorageSize(Stream);
+#endif
     }
 }
 

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -10,6 +10,7 @@
 
 #include "BP5Base.h"
 #include "adios2/core/Attribute.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/core/IO.h"
 #include "adios2/toolkit/format/buffer/BufferV.h"
 #include "adios2/toolkit/format/buffer/heap/BufferSTL.h"
@@ -93,10 +94,10 @@ public:
         const format::Buffer *AttributeEncodeBuffer, uint64_t DataSize,
         uint64_t WriterDataPos) const;
 
-    std::vector<BufferV::iovec> BreakoutContiguousMetadata(
+    std::vector<core::iovec> BreakoutContiguousMetadata(
         std::vector<char> *Aggregate, const std::vector<size_t> Counts,
         std::vector<MetaMetaInfoBlock> &UniqueMetaMetaBlocks,
-        std::vector<BufferV::iovec> &AttributeBlocks,
+        std::vector<core::iovec> &AttributeBlocks,
         std::vector<uint64_t> &DataSizes,
         std::vector<uint64_t> &WriterDataPositions) const;
 

--- a/source/adios2/toolkit/format/buffer/BufferV.h
+++ b/source/adios2/toolkit/format/buffer/BufferV.h
@@ -9,6 +9,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 #include <iostream>
 
 namespace adios2
@@ -21,19 +22,12 @@ class BufferV
 public:
     const std::string m_Type;
 
-    typedef struct iovec
-    {
-        const void
-            *iov_base;  //  Base address of a memory region for input or output.
-        size_t iov_len; //  The size of the memory pointed to by iov_base.
-    } * BufferV_iovec;
-
     uint64_t Size() noexcept;
 
     BufferV(const std::string type, const bool AlwaysCopy = false);
     virtual ~BufferV();
 
-    virtual BufferV_iovec DataVec() noexcept = 0;
+    virtual std::vector<core::iovec> DataVec() noexcept = 0;
 
     /*
      *  This is used in PerformPuts() to copy externally referenced data so that

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
@@ -218,17 +218,16 @@ void *ChunkV::GetPtr(int bufferIdx, size_t posInBuffer)
     }
 }
 
-ChunkV::BufferV_iovec ChunkV::DataVec() noexcept
+std::vector<core::iovec> ChunkV::DataVec() noexcept
 {
-    BufferV_iovec ret = new iovec[DataV.size() + 1];
+    std::vector<core::iovec> iov(DataV.size());
     for (std::size_t i = 0; i < DataV.size(); ++i)
     {
         // For ChunkV, all entries in DataV are actual iov entries.
-        ret[i].iov_base = DataV[i].Base;
-        ret[i].iov_len = DataV[i].Size;
+        iov[i].iov_base = DataV[i].Base;
+        iov[i].iov_len = DataV[i].Size;
     }
-    ret[DataV.size()] = {NULL, 0};
-    return ret;
+    return iov;
 }
 
 } // end namespace format

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
@@ -9,6 +9,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 
 #include "adios2/toolkit/format/buffer/BufferV.h"
 
@@ -28,7 +29,7 @@ public:
            const size_t ChunkSize = DefaultBufferChunkSize);
     virtual ~ChunkV();
 
-    virtual BufferV_iovec DataVec() noexcept;
+    virtual std::vector<core::iovec> DataVec() noexcept;
 
     virtual size_t AddToVec(const size_t size, const void *buf, size_t align,
                             bool CopyReqd);

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
@@ -195,23 +195,22 @@ void *MallocV::GetPtr(int bufferIdx, size_t posInBuffer)
     }
 }
 
-MallocV::BufferV_iovec MallocV::DataVec() noexcept
+std::vector<core::iovec> MallocV::DataVec() noexcept
 {
-    BufferV_iovec ret = new iovec[DataV.size() + 1];
+    std::vector<core::iovec> iov(DataV.size());
     for (std::size_t i = 0; i < DataV.size(); ++i)
     {
         if (DataV[i].External)
         {
-            ret[i].iov_base = DataV[i].Base;
+            iov[i].iov_base = DataV[i].Base;
         }
         else
         {
-            ret[i].iov_base = m_InternalBlock + DataV[i].Offset;
+            iov[i].iov_base = m_InternalBlock + DataV[i].Offset;
         }
-        ret[i].iov_len = DataV[i].Size;
+        iov[i].iov_len = DataV[i].Size;
     }
-    ret[DataV.size()] = {NULL, 0};
-    return ret;
+    return iov;
 }
 
 } // end namespace format

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.h
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.h
@@ -9,6 +9,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 
 #include "adios2/toolkit/format/buffer/BufferV.h"
 
@@ -27,7 +28,7 @@ public:
             double GrowthFactor = DefaultBufferGrowthFactor);
     virtual ~MallocV();
 
-    virtual BufferV_iovec DataVec() noexcept;
+    virtual std::vector<core::iovec> DataVec() noexcept;
 
     /**
      * Reset the buffer to initial state (without freeing internal buffers)

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -38,6 +38,10 @@ void Transport::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
             Write(static_cast<const char *>(iov[c].iov_base), iov[c].iov_len);
         }
     }
+    else if (start != MaxSizeT)
+    {
+        Seek(start);
+    }
 }
 
 void Transport::IRead(char *buffer, size_t size, Status &status, size_t start)

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -27,6 +27,19 @@ void Transport::IWrite(const char *buffer, size_t size, Status &status,
     throw std::invalid_argument("ERROR: this class doesn't implement IWrite\n");
 }
 
+void Transport::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
+{
+    if (iovcnt > 0)
+    {
+        Write(static_cast<const char *>(iov[0].iov_base), iov[0].iov_len,
+              start);
+        for (int c = 1; c < iovcnt; ++c)
+        {
+            Write(static_cast<const char *>(iov[c].iov_base), iov[c].iov_len);
+        }
+    }
+}
+
 void Transport::IRead(char *buffer, size_t size, Status &status, size_t start)
 {
     throw std::invalid_argument("ERROR: this class doesn't implement IRead\n");

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -152,6 +152,8 @@ public:
 
     virtual void SeekToBegin() = 0;
 
+    virtual void Seek(const size_t start = MaxSizeT) = 0;
+
 protected:
     virtual void MkDir(const std::string &fileName);
 

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -18,6 +18,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/toolkit/profiling/iochrono/IOChrono.h"
 
@@ -104,6 +105,17 @@ public:
                        size_t start = MaxSizeT) = 0;
 
     virtual void IWrite(const char *buffer, size_t size, Status &status,
+                        size_t start = MaxSizeT);
+
+    /**
+     * Writes to transport, writev version. Note that size is non-const due to
+     * the nature of underlying transport libraries
+     * @param iovec array pointer
+     * @param iovcnt number of entries
+     * @param start starting position for writing (to allow rewind), if not
+     * passed then start at current stream position
+     */
+    virtual void WriteV(const core::iovec *iov, const int iovcnt,
                         size_t start = MaxSizeT);
 
     /**

--- a/source/adios2/toolkit/transport/file/FileDaos.cpp
+++ b/source/adios2/toolkit/transport/file/FileDaos.cpp
@@ -338,5 +338,27 @@ void FileDaos::SeekToBegin()
     }
 }
 
+void FileDaos::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        errno = 0;
+        const int status = lseek(m_FileDescriptor, start, SEEK_SET);
+        m_Errno = errno;
+        if (status == -1)
+        {
+            throw std::ios_base::failure("ERROR: couldn't seek to offset " +
+                                         std::to_string(start) + " of file " +
+                                         m_Name + ", in call to DAOS IO lseek" +
+                                         SysErrMsg());
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileDaos.h
+++ b/source/adios2/toolkit/transport/file/FileDaos.h
@@ -52,6 +52,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** DAOS file handle returned by Open */
     int m_FileDescriptor = -1;

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -339,5 +339,20 @@ void FileFStream::SeekToBegin()
               ", in call to fstream seekp");
 }
 
+void FileFStream::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        m_FileStream.seekp(start, std::ios_base::beg);
+        CheckFile("couldn't move to offset " + std::to_string(start) +
+                  " of file " + m_Name + ", in call to fstream seekp");
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileFStream.h
+++ b/source/adios2/toolkit/transport/file/FileFStream.h
@@ -57,6 +57,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** file stream using fstream library */
     std::fstream m_FileStream;

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -336,5 +336,24 @@ void FileIME::SeekToBegin()
     }
 }
 
+void FileIME::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        const int status =
+            ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
+        if (status == -1)
+        {
+            throw std::ios_base::failure(
+                "ERROR: couldn't seek to offset " + std::to_string(start) +
+                " of file " + m_Name + ", in call to IME IO lseek\n");
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -57,6 +57,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** POSIX file handle returned by Open */
     int m_FileDescriptor = -1;

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -287,6 +287,7 @@ void FilePOSIX::Write(const char *buffer, size_t size, size_t start)
     }
 }
 
+#ifdef REALLY_WANT_WRITEV
 void FilePOSIX::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
 {
     auto lf_Write = [&](const core::iovec *iov, const int iovcnt) {
@@ -378,6 +379,7 @@ void FilePOSIX::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
         cntTotal += cnt;
     }
 }
+#endif
 
 void FilePOSIX::Read(char *buffer, size_t size, size_t start)
 {

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -533,5 +533,27 @@ void FilePOSIX::SeekToBegin()
     }
 }
 
+void FilePOSIX::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        errno = 0;
+        const int status = lseek(m_FileDescriptor, start, SEEK_SET);
+        m_Errno = errno;
+        if (status == -1)
+        {
+            throw std::ios_base::failure(
+                "ERROR: couldn't seek to offset " + std::to_string(start) +
+                " of file " + m_Name + ", in call to POSIX IO lseek" +
+                SysErrMsg());
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -64,6 +64,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** POSIX file handle returned by Open */
     int m_FileDescriptor = -1;

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -42,6 +42,8 @@ public:
                    const bool async = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
+    void WriteV(const core::iovec *iov, const int iovcnt,
+                size_t start = MaxSizeT) final;
 
     void Read(char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -42,8 +42,12 @@ public:
                    const bool async = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
+
+#ifdef REALLY_WANT_WRITEV
+    /* Actual writev() function, inactive for now */
     void WriteV(const core::iovec *iov, const int iovcnt,
                 size_t start = MaxSizeT) final;
+#endif
 
     void Read(char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -41,11 +41,15 @@ FileStdio::~FileStdio()
 
 void FileStdio::WaitForOpen()
 {
+    std::cout << "Wait for open file: " << m_Name << ", is opening "
+              << m_IsOpening << " valid " << m_OpenFuture.valid() << std::endl;
     if (m_IsOpening)
     {
         if (m_OpenFuture.valid())
         {
             m_File = m_OpenFuture.get();
+            std::cout << "After OpenFuture.get on file " << m_Name
+                      << " m_File is " << (void *)m_File << std::endl;
         }
         m_IsOpening = false;
         CheckFile(
@@ -70,6 +74,7 @@ void FileStdio::Open(const std::string &name, const Mode openMode,
     CheckName();
     m_OpenMode = openMode;
 
+    std::cout << "Doing open on " << name << std::endl;
     switch (m_OpenMode)
     {
     case (Mode::Write):
@@ -100,6 +105,7 @@ void FileStdio::Open(const std::string &name, const Mode openMode,
                                      m_Name + ", in call to stdio fopen");
     }
 
+    std::cout << "mfile is " << (void *)m_File << std::endl;
     if (!m_IsOpening)
     {
         CheckFile(

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -359,5 +359,24 @@ void FileStdio::SeekToBegin()
     }
 }
 
+void FileStdio::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        const auto status = std::fseek(m_File, 0, SEEK_SET);
+        if (status == -1)
+        {
+            throw std::ios_base::failure("ERROR: couldn't seek to offset " +
+                                         std::to_string(start) + " of file " +
+                                         m_Name + ", in call to stdio fseek\n");
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -55,6 +55,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start) final;
+
 private:
     /** C File pointer */
     FILE *m_File = nullptr;

--- a/source/adios2/toolkit/transport/null/NullTransport.cpp
+++ b/source/adios2/toolkit/transport/null/NullTransport.cpp
@@ -131,6 +131,16 @@ void NullTransport::SeekToBegin()
     Impl->CurPos = 0;
 }
 
+void NullTransport::Seek(const size_t start)
+{
+    if (!Impl->IsOpen)
+    {
+        throw std::runtime_error(
+            "ERROR: NullTransport::SeekToEnd: The transport is not open.");
+    }
+    Impl->CurPos = start;
+}
+
 void NullTransport::MkDir(const std::string &fileName) { return; }
 
 void NullTransport::CheckName() const { return; }

--- a/source/adios2/toolkit/transport/null/NullTransport.h
+++ b/source/adios2/toolkit/transport/null/NullTransport.h
@@ -56,6 +56,8 @@ public:
 
     void SeekToBegin() override;
 
+    void Seek(const size_t start = MaxSizeT) override;
+
 protected:
     struct NullTransportImpl;
     std::unique_ptr<NullTransportImpl> Impl;

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
@@ -145,6 +145,11 @@ void ShmSystemV::SeekToBegin()
     // empty function. seek operation is meaningless for shared memory
 }
 
+void ShmSystemV::Seek(const size_t start)
+{
+    // empty function. seek operation is meaningless for shared memory
+}
+
 // PRIVATE
 void ShmSystemV::CheckShmID(const std::string hint) const
 {

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.h
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.h
@@ -51,6 +51,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** 1st argument of ftok to create shared memory segment key, from Open */
     std::string m_PathName;

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -243,6 +243,53 @@ void TransportMan::WriteFileAt(const char *buffer, const size_t size,
     }
 }
 
+void TransportMan::WriteFiles(const core::iovec *iov, const size_t iovcnt,
+                              const int transportIndex)
+{
+    if (transportIndex == -1)
+    {
+        for (auto &transportPair : m_Transports)
+        {
+            auto &transport = transportPair.second;
+            if (transport->m_Type == "File")
+            {
+                // make this truly asynch?
+                transport->WriteV(iov, static_cast<int>(iovcnt));
+            }
+        }
+    }
+    else
+    {
+        auto itTransport = m_Transports.find(transportIndex);
+        CheckFile(itTransport, ", in call to WriteFiles with index " +
+                                   std::to_string(transportIndex));
+        itTransport->second->WriteV(iov, static_cast<int>(iovcnt));
+    }
+}
+
+void TransportMan::WriteFileAt(const core::iovec *iov, const size_t iovcnt,
+                               const size_t start, const int transportIndex)
+{
+    if (transportIndex == -1)
+    {
+        for (auto &transportPair : m_Transports)
+        {
+            auto &transport = transportPair.second;
+            if (transport->m_Type == "File")
+            {
+                transport->WriteV(iov, static_cast<int>(iovcnt), start);
+            }
+        }
+    }
+    else
+    {
+        auto itTransport = m_Transports.find(transportIndex);
+        CheckFile(itTransport, ", in call to WriteFileAt with index " +
+                                   std::to_string(transportIndex));
+        itTransport->second->WriteV(iov, static_cast<int>(iovcnt), start);
+    }
+}
+
 void TransportMan::SeekToFileEnd(const int transportIndex)
 {
     if (transportIndex == -1)

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "adios2/core/CoreTypes.h"
 #include "adios2/toolkit/transport/Transport.h"
 
 namespace adios2
@@ -137,9 +138,29 @@ public:
      * @param transportIndex
      * @param buffer
      * @param size
+     * @param start offset in file
      */
     void WriteFileAt(const char *buffer, const size_t size, const size_t start,
                      const int transportIndex = -1);
+
+    /**
+     * Write to file transports, writev version
+     * @param transportIndex
+     * @param iovec array pointer
+     * @param iovcnt number of entries
+     */
+    void WriteFiles(const core::iovec *iov, const size_t iovcnt,
+                    const int transportIndex = -1);
+
+    /**
+     * Write data to a specific location in files, writev version
+     * @param transportIndex
+     * @param iovec array pointer
+     * @param iovcnt number of entries
+     * @param start offset in file
+     */
+    void WriteFileAt(const core::iovec *iov, const size_t iovcnt,
+                     const size_t start, const int transportIndex = -1);
 
     size_t GetFileSize(const size_t transportIndex = 0) const;
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -19,9 +19,6 @@ macro(bp3_bp4_gtest_add_tests_helper testname mpi)
   gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .BP4
     WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4"
   )
-#  gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .BP5
-#    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
-#  )
 endmacro()
 
 macro(bp_gtest_add_tests_helper testname mpi)
@@ -40,11 +37,11 @@ endmacro()
 
 add_subdirectory(operations)
 
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2 MPI_ALLOW)
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2fstream MPI_ALLOW)
+bp_gtest_add_tests_helper(WriteReadADIOS2 MPI_ALLOW)
+bp_gtest_add_tests_helper(WriteReadADIOS2fstream MPI_ALLOW)
 bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2stdio MPI_ALLOW)
-bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2 MPI_ALLOW)
-bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2_Threads MPI_ALLOW)
+bp_gtest_add_tests_helper(WriteReadAsStreamADIOS2 MPI_ALLOW)
+bp_gtest_add_tests_helper(WriteReadAsStreamADIOS2_Threads MPI_ALLOW)
 bp3_bp4_gtest_add_tests_helper(WriteReadAttributes MPI_ALLOW)
 bp3_bp4_gtest_add_tests_helper(FStreamWriteReadHighLevelAPI MPI_ALLOW)
 bp3_bp4_gtest_add_tests_helper(WriteFlushRead MPI_ALLOW)

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -224,10 +224,10 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
             io.SetEngine(engineName);
         }
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         EXPECT_EQ(bpReader.Steps(), NSteps);
-        EXPECT_EQ(bpReader.OpenMode(), adios2::Mode::Read);
 
         // auto var_bool = io.InquireVariable<bool>("bool");
         // EXPECT_TRUE(var_bool);
@@ -566,7 +566,8 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D2x4)
             io.SetEngine(engineName);
         }
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         EXPECT_EQ(bpReader.Steps(), NSteps);
         auto var_iString = io.InquireVariable<std::string>("iString");
@@ -883,7 +884,8 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2)
             io.SetEngine(engineName);
         }
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         EXPECT_EQ(bpReader.Steps(), NSteps);
 
@@ -1148,7 +1150,8 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead10D2x2)
             io.SetEngine(engineName);
         }
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         EXPECT_EQ(bpReader.Steps(), NSteps);
 
@@ -1366,7 +1369,8 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
             io.SetEngine(engineName);
         }
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         EXPECT_EQ(bpReader.Steps(), NSteps);
 
@@ -1485,6 +1489,8 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
         var_r32.SetStepSelection({tInitial, NSteps - tInitial});
         var_r64.SetStepSelection({tInitial, NSteps - tInitial});
 
+        std::cout << "Step selection is " << tInitial << " to "
+                  << NSteps - tInitial << std::endl;
         bpReader.Get(var_i8, I8.data());
         bpReader.Get(var_i16, I16.data());
         bpReader.Get(var_i32, I32.data());
@@ -1513,6 +1519,8 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
                 ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
+                std::cout << "Testing i8 at i = " << i << " index = " << index
+                          << " data eq " << (void *)&I8[index] << std::endl;
                 EXPECT_EQ(I8[index], currentTestData.I8[i]) << msg;
                 EXPECT_EQ(I16[index], currentTestData.I16[i]) << msg;
                 EXPECT_EQ(I32[index], currentTestData.I32[i]) << msg;
@@ -1673,7 +1681,8 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_MultiStepsOverflow)
             io.SetEngine(engineName);
         }
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         auto var_i16 = io.InquireVariable<int16_t>("i16");
@@ -1779,7 +1788,8 @@ TEST_F(BPWriteReadTestADIOS2, OpenEngineTwice)
         bpWriter.Close();
 
         EXPECT_NO_THROW(io.Open(fname, adios2::Mode::Write));
-        EXPECT_THROW(io.Open(fname, adios2::Mode::Read), std::invalid_argument);
+        EXPECT_THROW(io.Open(fname, adios2::Mode::ReadRandomAccess),
+                     std::invalid_argument);
     }
 }
 
@@ -1830,7 +1840,8 @@ TEST_F(BPWriteReadTestADIOS2, ReadStartCount)
             io.SetEngine(engineName);
         }
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
         adios2::Variable<int64_t> varRange =
             io.InquireVariable<int64_t>("range");
 

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -1865,6 +1865,7 @@ TEST_F(BPWriteReadTestADIOS2, ReadStartCount)
 // ADIOS2 BP write and read 1D arrays
 TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteReadEmptyProcess)
 {
+#if ADIOS2_USE_MPI
     // Each process, except rank 0 would write a 1x8 array and all
     // processes would form a (mpiSize-1) * Nx 1D array
     const std::string fname("ADIOS2BPWriteReadEmptyProces.bp");
@@ -1876,14 +1877,9 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteReadEmptyProcess)
     // Number of steps
     const size_t NSteps = 3;
 
-#if ADIOS2_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
 
-    // Write test data using BP
-
-#if ADIOS2_USE_MPI
     /* This is a parallel test, do not run in serial */
     adios2::ADIOS adios(MPI_COMM_WORLD);
     {

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -1858,6 +1858,159 @@ TEST_F(BPWriteReadTestADIOS2, ReadStartCount)
     }
 }
 
+//***************************************************
+// 1D test where some process does not write anything
+//***************************************************
+
+// ADIOS2 BP write and read 1D arrays
+TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteReadEmptyProcess)
+{
+    // Each process, except rank 0 would write a 1x8 array and all
+    // processes would form a (mpiSize-1) * Nx 1D array
+    const std::string fname("ADIOS2BPWriteReadEmptyProces.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 8;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
+
+#if ADIOS2_USE_MPI
+    /* This is a parallel test, do not run in serial */
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+        // Declare 1D variables (NumOfProcesses * Nx)
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
+
+        adios2::Dims shape{static_cast<size_t>(Nx * (mpiSize - 1))};
+        adios2::Dims start{static_cast<size_t>(Nx * (mpiRank - 1))};
+        adios2::Dims count{Nx};
+        if (!mpiRank)
+        {
+            count[0] = 0;
+            start[0] = 0;
+        }
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count);
+        EXPECT_TRUE(var_r32);
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            bpWriter.BeginStep();
+            if (!mpiRank)
+            {
+                // in first step, rank 0 does not call Put
+                // in second step, it calls with a zero sized array
+                // in third step, it calls with nullptr
+                if (step == 1)
+                {
+                    std::vector<float> zero;
+                    bpWriter.Put(var_r32, zero.data());
+                }
+                else if (step == 2)
+                {
+                    bpWriter.Put(var_r32, (float *)0);
+                }
+            }
+            else
+            {
+                bpWriter.Put(var_r32, currentTestData.R32.data());
+            }
+
+            bpWriter.EndStep();
+        }
+
+        // Close the file
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank + 1, mpiSize);
+
+            bpReader.BeginStep();
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Shape()[0], (mpiSize - 1) * Nx);
+
+            SmallTestData testData;
+            std::array<float, Nx> R32;
+
+            // last process does not read
+            // readers 0..N-2, while data was produced by 1..N-1
+            adios2::Dims start{mpiRank * Nx};
+            adios2::Dims count{Nx};
+
+            if (mpiRank == mpiSize - 1)
+            {
+                count[0] = 0;
+                start[0] = 0;
+            }
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+            var_r32.SetSelection(sel);
+
+            if (mpiRank < mpiSize - 1)
+            {
+                bpReader.Get(var_r32, R32.data(), adios2::Mode::Sync);
+                for (size_t i = 0; i < Nx; ++i)
+                {
+                    std::stringstream ss;
+                    ss << "t=" << step << " i=" << i << " rank=" << mpiRank;
+                    std::string msg = ss.str();
+                    EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                }
+            }
+
+            bpReader.EndStep();
+        }
+        bpReader.Close();
+    }
+#else
+    return;
+#endif
+}
+
 //******************************************************************************
 // main
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -1935,12 +1935,12 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteReadEmptyProcess)
                 // in first step, rank 0 does not call Put
                 // in second step, it calls with a zero sized array
                 // in third step, it calls with nullptr
-                if (step == 1)
+                if (step == 3)
                 {
                     std::vector<float> zero;
                     bpWriter.Put(var_r32, zero.data());
                 }
-                else if (step == 2)
+                else if (step == 3)
                 {
                     bpWriter.Put(var_r32, (float *)0);
                 }

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2fstream.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2fstream.cpp
@@ -184,7 +184,8 @@ TEST_F(BPWriteReadTestADIOS2fstream, ADIOS2BPWriteRead1D8)
         }
         io.AddTransport("file", {{"Library", "fstream"}});
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_iString = io.InquireVariable<std::string>("iString");
         EXPECT_TRUE(var_iString);
@@ -531,7 +532,8 @@ TEST_F(BPWriteReadTestADIOS2fstream, ADIOS2BPWriteRead2D2x4)
         }
         io.AddTransport("file", {{"Library", "fstream"}});
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_iString = io.InquireVariable<std::string>("iString");
         EXPECT_TRUE(var_iString);
@@ -878,7 +880,8 @@ TEST_F(BPWriteReadTestADIOS2fstream, ADIOS2BPWriteRead2D4x2)
         }
         io.AddTransport("file", {{"Library", "fstream"}});
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         EXPECT_TRUE(var_i8);
@@ -1214,7 +1217,8 @@ TEST_F(BPWriteReadTestADIOS2fstream, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
         }
         io.AddTransport("file", {{"Library", "fstream"}});
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         EXPECT_TRUE(var_i8);
@@ -1539,7 +1543,8 @@ TEST_F(BPWriteReadTestADIOS2fstream, ADIOS2BPWriteRead2D4x2_MultiStepsOverflow)
         }
         io.AddTransport("file", {{"Library", "fstream"}});
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         auto var_i16 = io.InquireVariable<int16_t>("i16");
@@ -1640,7 +1645,8 @@ TEST_F(BPWriteReadTestADIOS2fstream, OpenEngineTwice)
         bpWriter.Close();
 
         EXPECT_NO_THROW(io.Open(fname, adios2::Mode::Write));
-        EXPECT_THROW(io.Open(fname, adios2::Mode::Read), std::invalid_argument);
+        EXPECT_THROW(io.Open(fname, adios2::Mode::ReadRandomAccess),
+                     std::invalid_argument);
     }
 }
 

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
@@ -211,7 +211,6 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8)
                 EXPECT_TRUE(var_iString);
                 EXPECT_TRUE(var_iString);
                 ASSERT_EQ(var_iString.Shape().size(), 0);
-                ASSERT_EQ(var_iString.Steps(), 1);
             }
             else
             {
@@ -230,21 +229,17 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8)
                 EXPECT_FALSE(var_u64);
 
                 ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_i8.Steps(), NSteps / 2 + NSteps % 2);
                 ASSERT_EQ(var_i8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
                 ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_i16.Steps(), NSteps / 2 + NSteps % 2);
                 ASSERT_EQ(var_i16.Shape()[0],
                           static_cast<size_t>(mpiSize * Nx));
 
                 ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_i32.Steps(), NSteps / 2 + NSteps % 2);
                 ASSERT_EQ(var_i32.Shape()[0],
                           static_cast<size_t>(mpiSize * Nx));
 
                 ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_i64.Steps(), NSteps / 2 + NSteps % 2);
                 ASSERT_EQ(var_i64.Shape()[0],
                           static_cast<size_t>(mpiSize * Nx));
 
@@ -271,19 +266,15 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8)
                 EXPECT_TRUE(var_u64);
 
                 ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_u8.Steps(), NSteps / 2);
                 ASSERT_EQ(var_u8.Shape()[0], mpiSize * Nx);
 
                 ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_u16.Steps(), NSteps / 2);
                 ASSERT_EQ(var_u16.Shape()[0], mpiSize * Nx);
 
                 ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_u32.Steps(), NSteps / 2);
                 ASSERT_EQ(var_u32.Shape()[0], mpiSize * Nx);
 
                 ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_u64.Steps(), NSteps / 2);
                 ASSERT_EQ(var_u64.Shape()[0], mpiSize * Nx);
 
                 var_u8.SetSelection(sel);
@@ -308,11 +299,9 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8)
                 EXPECT_TRUE(var_r64);
 
                 ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_r32.Steps(), NSteps - 1);
                 ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
 
                 ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-                ASSERT_EQ(var_r64.Steps(), NSteps - 1);
                 ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
 
                 var_r32.SetSelection(sel);
@@ -326,11 +315,9 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8)
             EXPECT_TRUE(var_cr64);
 
             ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr32.Steps(), NSteps);
             ASSERT_EQ(var_cr32.Shape()[0], mpiSize * Nx);
 
             ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr64.Steps(), NSteps);
             ASSERT_EQ(var_cr64.Shape()[0], mpiSize * Nx);
 
             var_cr32.SetSelection(sel);
@@ -525,70 +512,60 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D2x4)
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             EXPECT_TRUE(var_i8);
             ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i8.Steps(), NSteps);
             ASSERT_EQ(var_i8.Shape()[0], Ny);
             ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i16 = io.InquireVariable<int16_t>("i16");
             EXPECT_TRUE(var_i16);
             ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i16.Steps(), NSteps);
             ASSERT_EQ(var_i16.Shape()[0], Ny);
             ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i32 = io.InquireVariable<int32_t>("i32");
             EXPECT_TRUE(var_i32);
             ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i32.Steps(), NSteps);
             ASSERT_EQ(var_i32.Shape()[0], Ny);
             ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i64 = io.InquireVariable<int64_t>("i64");
             EXPECT_TRUE(var_i64);
             ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i64.Steps(), NSteps);
             ASSERT_EQ(var_i64.Shape()[0], Ny);
             ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u8 = io.InquireVariable<uint8_t>("u8");
             EXPECT_TRUE(var_u8);
             ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u8.Steps(), NSteps);
             ASSERT_EQ(var_u8.Shape()[0], Ny);
             ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u16 = io.InquireVariable<uint16_t>("u16");
             EXPECT_TRUE(var_u16);
             ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u16.Steps(), NSteps);
             ASSERT_EQ(var_u16.Shape()[0], Ny);
             ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u32 = io.InquireVariable<uint32_t>("u32");
             EXPECT_TRUE(var_u32);
             ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u32.Steps(), NSteps);
             ASSERT_EQ(var_u32.Shape()[0], Ny);
             ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u64 = io.InquireVariable<uint64_t>("u64");
             EXPECT_TRUE(var_u64);
             ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u64.Steps(), NSteps);
             ASSERT_EQ(var_u64.Shape()[0], Ny);
             ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r32 = io.InquireVariable<float>("r32");
             EXPECT_TRUE(var_r32);
             ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r32.Steps(), NSteps);
             ASSERT_EQ(var_r32.Shape()[0], Ny);
             ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r64 = io.InquireVariable<double>("r64");
             EXPECT_TRUE(var_r64);
             ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r64.Steps(), NSteps);
             ASSERT_EQ(var_r64.Shape()[0], Ny);
             ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
@@ -790,70 +767,60 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D4x2)
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             EXPECT_TRUE(var_i8);
             ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i8.Steps(), NSteps);
             ASSERT_EQ(var_i8.Shape()[0], Ny);
             ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i16 = io.InquireVariable<int16_t>("i16");
             EXPECT_TRUE(var_i16);
             ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i16.Steps(), NSteps);
             ASSERT_EQ(var_i16.Shape()[0], Ny);
             ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i32 = io.InquireVariable<int32_t>("i32");
             EXPECT_TRUE(var_i32);
             ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i32.Steps(), NSteps);
             ASSERT_EQ(var_i32.Shape()[0], Ny);
             ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i64 = io.InquireVariable<int64_t>("i64");
             EXPECT_TRUE(var_i64);
             ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i64.Steps(), NSteps);
             ASSERT_EQ(var_i64.Shape()[0], Ny);
             ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u8 = io.InquireVariable<uint8_t>("u8");
             EXPECT_TRUE(var_u8);
             ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u8.Steps(), NSteps);
             ASSERT_EQ(var_u8.Shape()[0], Ny);
             ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u16 = io.InquireVariable<uint16_t>("u16");
             EXPECT_TRUE(var_u16);
             ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u16.Steps(), NSteps);
             ASSERT_EQ(var_u16.Shape()[0], Ny);
             ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u32 = io.InquireVariable<uint32_t>("u32");
             EXPECT_TRUE(var_u32);
             ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u32.Steps(), NSteps);
             ASSERT_EQ(var_u32.Shape()[0], Ny);
             ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u64 = io.InquireVariable<uint64_t>("u64");
             EXPECT_TRUE(var_u64);
             ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u64.Steps(), NSteps);
             ASSERT_EQ(var_u64.Shape()[0], Ny);
             ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r32 = io.InquireVariable<float>("r32");
             EXPECT_TRUE(var_r32);
             ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r32.Steps(), NSteps);
             ASSERT_EQ(var_r32.Shape()[0], Ny);
             ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r64 = io.InquireVariable<double>("r64");
             EXPECT_TRUE(var_r64);
             ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r64.Steps(), NSteps);
             ASSERT_EQ(var_r64.Shape()[0], Ny);
             ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
@@ -137,66 +137,6 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead1D8)
         io.SetParameter("Threads", "2");
         adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
 
-        auto var_i8 = io.InquireVariable<int8_t>("i8");
-        EXPECT_TRUE(var_i8);
-        ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i8.Steps(), NSteps);
-        ASSERT_EQ(var_i8.Shape()[0], mpiSize * Nx);
-
-        auto var_i16 = io.InquireVariable<int16_t>("i16");
-        EXPECT_TRUE(var_i16);
-        ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i16.Steps(), NSteps);
-        ASSERT_EQ(var_i16.Shape()[0], mpiSize * Nx);
-
-        auto var_i32 = io.InquireVariable<int32_t>("i32");
-        EXPECT_TRUE(var_i32);
-        ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i32.Steps(), NSteps);
-        ASSERT_EQ(var_i32.Shape()[0], mpiSize * Nx);
-
-        auto var_i64 = io.InquireVariable<int64_t>("i64");
-        EXPECT_TRUE(var_i64);
-        ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i64.Steps(), NSteps);
-        ASSERT_EQ(var_i64.Shape()[0], mpiSize * Nx);
-
-        auto var_u8 = io.InquireVariable<uint8_t>("u8");
-        EXPECT_TRUE(var_u8);
-        ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u8.Steps(), NSteps);
-        ASSERT_EQ(var_u8.Shape()[0], mpiSize * Nx);
-
-        auto var_u16 = io.InquireVariable<uint16_t>("u16");
-        EXPECT_TRUE(var_u16);
-        ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u16.Steps(), NSteps);
-        ASSERT_EQ(var_u16.Shape()[0], mpiSize * Nx);
-
-        auto var_u32 = io.InquireVariable<uint32_t>("u32");
-        EXPECT_TRUE(var_u32);
-        ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u32.Steps(), NSteps);
-        ASSERT_EQ(var_u32.Shape()[0], mpiSize * Nx);
-
-        auto var_u64 = io.InquireVariable<uint64_t>("u64");
-        EXPECT_TRUE(var_u64);
-        ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u64.Steps(), NSteps);
-        ASSERT_EQ(var_u64.Shape()[0], mpiSize * Nx);
-
-        auto var_r32 = io.InquireVariable<float>("r32");
-        EXPECT_TRUE(var_r32);
-        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_r32.Steps(), NSteps);
-        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
-
-        auto var_r64 = io.InquireVariable<double>("r64");
-        EXPECT_TRUE(var_r64);
-        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_r64.Steps(), NSteps);
-        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
-
         std::string IString;
         std::array<int8_t, Nx> I8;
         std::array<int16_t, Nx> I16;
@@ -214,25 +154,75 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead1D8)
 
         const adios2::Box<adios2::Dims> sel(start, count);
 
-        var_i8.SetSelection(sel);
-        var_i16.SetSelection(sel);
-        var_i32.SetSelection(sel);
-        var_i64.SetSelection(sel);
-
-        var_u8.SetSelection(sel);
-        var_u16.SetSelection(sel);
-        var_u32.SetSelection(sel);
-        var_u64.SetSelection(sel);
-
-        var_r32.SetSelection(sel);
-        var_r64.SetSelection(sel);
-
         unsigned int t = 0;
 
         while (bpReader.BeginStep() == adios2::StepStatus::OK)
         {
             const size_t currentStep = bpReader.CurrentStep();
             EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            EXPECT_TRUE(var_i8);
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8.Shape()[0], mpiSize * Nx);
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            EXPECT_TRUE(var_i16);
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16.Shape()[0], mpiSize * Nx);
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            EXPECT_TRUE(var_i32);
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32.Shape()[0], mpiSize * Nx);
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            EXPECT_TRUE(var_i64);
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64.Shape()[0], mpiSize * Nx);
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            EXPECT_TRUE(var_u8);
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8.Shape()[0], mpiSize * Nx);
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            EXPECT_TRUE(var_u16);
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16.Shape()[0], mpiSize * Nx);
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            EXPECT_TRUE(var_u32);
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32.Shape()[0], mpiSize * Nx);
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            EXPECT_TRUE(var_u64);
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64.Shape()[0], mpiSize * Nx);
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
 
             SmallTestData currentTestData = generateNewSmallTestData(
                 m_TestData, static_cast<int>(currentStep), mpiRank, mpiSize);
@@ -395,76 +385,6 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D2x4)
         io.SetParameter("Threads", "2");
         adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
 
-        auto var_i8 = io.InquireVariable<int8_t>("i8");
-        EXPECT_TRUE(var_i8);
-        ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i8.Steps(), NSteps);
-        ASSERT_EQ(var_i8.Shape()[0], Ny);
-        ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_i16 = io.InquireVariable<int16_t>("i16");
-        EXPECT_TRUE(var_i16);
-        ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i16.Steps(), NSteps);
-        ASSERT_EQ(var_i16.Shape()[0], Ny);
-        ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_i32 = io.InquireVariable<int32_t>("i32");
-        EXPECT_TRUE(var_i32);
-        ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i32.Steps(), NSteps);
-        ASSERT_EQ(var_i32.Shape()[0], Ny);
-        ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_i64 = io.InquireVariable<int64_t>("i64");
-        EXPECT_TRUE(var_i64);
-        ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i64.Steps(), NSteps);
-        ASSERT_EQ(var_i64.Shape()[0], Ny);
-        ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u8 = io.InquireVariable<uint8_t>("u8");
-        EXPECT_TRUE(var_u8);
-        ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u8.Steps(), NSteps);
-        ASSERT_EQ(var_u8.Shape()[0], Ny);
-        ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u16 = io.InquireVariable<uint16_t>("u16");
-        EXPECT_TRUE(var_u16);
-        ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u16.Steps(), NSteps);
-        ASSERT_EQ(var_u16.Shape()[0], Ny);
-        ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u32 = io.InquireVariable<uint32_t>("u32");
-        EXPECT_TRUE(var_u32);
-        ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u32.Steps(), NSteps);
-        ASSERT_EQ(var_u32.Shape()[0], Ny);
-        ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u64 = io.InquireVariable<uint64_t>("u64");
-        EXPECT_TRUE(var_u64);
-        ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u64.Steps(), NSteps);
-        ASSERT_EQ(var_u64.Shape()[0], Ny);
-        ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_r32 = io.InquireVariable<float>("r32");
-        EXPECT_TRUE(var_r32);
-        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_r32.Steps(), NSteps);
-        ASSERT_EQ(var_r32.Shape()[0], Ny);
-        ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_r64 = io.InquireVariable<double>("r64");
-        EXPECT_TRUE(var_r64);
-        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_r64.Steps(), NSteps);
-        ASSERT_EQ(var_r64.Shape()[0], Ny);
-        ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
         std::array<int8_t, Nx * Ny> I8;
         std::array<int16_t, Nx * Ny> I16;
         std::array<int32_t, Nx * Ny> I32;
@@ -481,25 +401,85 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D2x4)
 
         const adios2::Box<adios2::Dims> sel(start, count);
 
-        var_i8.SetSelection(sel);
-        var_i16.SetSelection(sel);
-        var_i32.SetSelection(sel);
-        var_i64.SetSelection(sel);
-
-        var_u8.SetSelection(sel);
-        var_u16.SetSelection(sel);
-        var_u32.SetSelection(sel);
-        var_u64.SetSelection(sel);
-
-        var_r32.SetSelection(sel);
-        var_r64.SetSelection(sel);
-
         unsigned int t = 0;
 
         while (bpReader.BeginStep() == adios2::StepStatus::OK)
         {
             const size_t currentStep = bpReader.CurrentStep();
             EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            EXPECT_TRUE(var_i8);
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8.Shape()[0], Ny);
+            ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            EXPECT_TRUE(var_i16);
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16.Shape()[0], Ny);
+            ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            EXPECT_TRUE(var_i32);
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32.Shape()[0], Ny);
+            ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            EXPECT_TRUE(var_i64);
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64.Shape()[0], Ny);
+            ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            EXPECT_TRUE(var_u8);
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8.Shape()[0], Ny);
+            ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            EXPECT_TRUE(var_u16);
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16.Shape()[0], Ny);
+            ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            EXPECT_TRUE(var_u32);
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32.Shape()[0], Ny);
+            ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            EXPECT_TRUE(var_u64);
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64.Shape()[0], Ny);
+            ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Shape()[0], Ny);
+            ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Shape()[0], Ny);
+            ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
 
             SmallTestData currentTestData = generateNewSmallTestData(
                 m_TestData, static_cast<int>(currentStep), mpiRank, mpiSize);
@@ -664,76 +644,6 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D4x2)
         io.SetParameter("Threads", "2");
         adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
 
-        auto var_i8 = io.InquireVariable<int8_t>("i8");
-        EXPECT_TRUE(var_i8);
-        ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i8.Steps(), NSteps);
-        ASSERT_EQ(var_i8.Shape()[0], Ny);
-        ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_i16 = io.InquireVariable<int16_t>("i16");
-        EXPECT_TRUE(var_i16);
-        ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i16.Steps(), NSteps);
-        ASSERT_EQ(var_i16.Shape()[0], Ny);
-        ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_i32 = io.InquireVariable<int32_t>("i32");
-        EXPECT_TRUE(var_i32);
-        ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i32.Steps(), NSteps);
-        ASSERT_EQ(var_i32.Shape()[0], Ny);
-        ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_i64 = io.InquireVariable<int64_t>("i64");
-        EXPECT_TRUE(var_i64);
-        ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_i64.Steps(), NSteps);
-        ASSERT_EQ(var_i64.Shape()[0], Ny);
-        ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u8 = io.InquireVariable<uint8_t>("u8");
-        EXPECT_TRUE(var_u8);
-        ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u8.Steps(), NSteps);
-        ASSERT_EQ(var_u8.Shape()[0], Ny);
-        ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u16 = io.InquireVariable<uint16_t>("u16");
-        EXPECT_TRUE(var_u16);
-        ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u16.Steps(), NSteps);
-        ASSERT_EQ(var_u16.Shape()[0], Ny);
-        ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u32 = io.InquireVariable<uint32_t>("u32");
-        EXPECT_TRUE(var_u32);
-        ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u32.Steps(), NSteps);
-        ASSERT_EQ(var_u32.Shape()[0], Ny);
-        ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_u64 = io.InquireVariable<uint64_t>("u64");
-        EXPECT_TRUE(var_u64);
-        ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_u64.Steps(), NSteps);
-        ASSERT_EQ(var_u64.Shape()[0], Ny);
-        ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_r32 = io.InquireVariable<float>("r32");
-        EXPECT_TRUE(var_r32);
-        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_r32.Steps(), NSteps);
-        ASSERT_EQ(var_r32.Shape()[0], Ny);
-        ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
-        auto var_r64 = io.InquireVariable<double>("r64");
-        EXPECT_TRUE(var_r64);
-        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-        ASSERT_EQ(var_r64.Steps(), NSteps);
-        ASSERT_EQ(var_r64.Shape()[0], Ny);
-        ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
-
         // If the size of the array is smaller than the data
         // the result is weird... double and uint64_t would get
         // completely garbage data
@@ -753,25 +663,85 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D4x2)
 
         const adios2::Box<adios2::Dims> sel(start, count);
 
-        var_i8.SetSelection(sel);
-        var_i16.SetSelection(sel);
-        var_i32.SetSelection(sel);
-        var_i64.SetSelection(sel);
-
-        var_u8.SetSelection(sel);
-        var_u16.SetSelection(sel);
-        var_u32.SetSelection(sel);
-        var_u64.SetSelection(sel);
-
-        var_r32.SetSelection(sel);
-        var_r64.SetSelection(sel);
-
         unsigned int t = 0;
 
         while (bpReader.BeginStep() == adios2::StepStatus::OK)
         {
             const size_t currentStep = bpReader.CurrentStep();
             EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            EXPECT_TRUE(var_i8);
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8.Shape()[0], Ny);
+            ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            EXPECT_TRUE(var_i16);
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16.Shape()[0], Ny);
+            ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            EXPECT_TRUE(var_i32);
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32.Shape()[0], Ny);
+            ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            EXPECT_TRUE(var_i64);
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64.Shape()[0], Ny);
+            ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            EXPECT_TRUE(var_u8);
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8.Shape()[0], Ny);
+            ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            EXPECT_TRUE(var_u16);
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16.Shape()[0], Ny);
+            ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            EXPECT_TRUE(var_u32);
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32.Shape()[0], Ny);
+            ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            EXPECT_TRUE(var_u64);
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64.Shape()[0], Ny);
+            ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Shape()[0], Ny);
+            ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Shape()[0], Ny);
+            ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
 
             SmallTestData currentTestData = generateNewSmallTestData(
                 m_TestData, static_cast<int>(currentStep), mpiRank, mpiSize);
@@ -932,7 +902,8 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads,
 
         io.SetParameter("Threads", "2");
 
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         EXPECT_TRUE(var_i8);
@@ -1190,7 +1161,8 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads,
         }
 
         io.SetParameter("Threads", "2");
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         EXPECT_TRUE(var_i8);
@@ -1459,7 +1431,8 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads,
         }
 
         io.SetParameter("Threads", "2");
-        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         EXPECT_TRUE(var_i8);

--- a/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 
 #include <adios2.h>
+#include <adios2_c.h>
 
 #include <gtest/gtest.h>
 
@@ -47,6 +48,59 @@ void CheckAllStepsBlockInfo1D(
             EXPECT_EQ(allStepsBlocksInfo[s][b].WriterID, b);
             EXPECT_FALSE(allStepsBlocksInfo[s][b].IsReverseDims);
         }
+    }
+}
+
+void CheckStepsBlockInfo1D_C(adios2_variable *var, adios2_varinfo *vi,
+                             const size_t NSteps, const size_t nproc,
+                             const size_t Nx)
+{
+    EXPECT_EQ(vi->nblocks, nproc);
+    adios2_shapeid shapeid;
+    adios2_variable_shapeid(&shapeid, var);
+    size_t namelen;
+    char name[128];
+    adios2_variable_name(name, &namelen, var);
+    name[namelen] = '\0';
+    // std::cout << "Check info on variable " << name << " shape = " << shapeid
+    //          << std::endl;
+    if (shapeid == adios2_shapeid_global_value)
+    {
+        // std::cout << "Global Value " << std::endl;
+        EXPECT_EQ(vi->IsValue, 1);
+        EXPECT_EQ(vi->Dims, 0);
+    }
+    else if (shapeid == adios2_shapeid_global_array)
+    {
+        // std::cout << "Global Array " << std::endl;
+        EXPECT_EQ(vi->Dims, 1);
+    }
+    else
+    {
+        // std::cout << "Unexpected shape ID " << std::endl;
+        throw std::invalid_argument(
+            "Variable " + std::string(name) +
+            " is expected to be a global value or array ");
+    }
+
+    EXPECT_FALSE(vi->IsReverseDims);
+
+    if (vi->Dims > 0)
+    {
+        size_t shape;
+        adios2_variable_shape(&shape, var);
+        EXPECT_EQ(vi->Shape[0], shape);
+    }
+
+    for (size_t b = 0; b < vi->nblocks; ++b)
+    {
+        EXPECT_EQ(vi->BlocksInfo[b].BlockID, b);
+        if (vi->Dims > 0)
+        {
+            EXPECT_EQ(vi->BlocksInfo[b].Start[0], b * Nx);
+            EXPECT_EQ(vi->BlocksInfo[b].Count[0], Nx);
+        }
+        EXPECT_EQ(vi->BlocksInfo[b].WriterID, b);
     }
 }
 
@@ -672,6 +726,186 @@ TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo2D2x4)
             }
         }
         bpReader.Close();
+    }
+}
+
+TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo1D8_C)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWriteReadblockInfo1D8.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 8;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
+    {
+#if ADIOS2_USE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+        adios2::ADIOS adios;
+#endif
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+        const adios2::Dims count{Nx};
+
+        auto var_local =
+            io.DefineVariable<int32_t>("local", {adios2::LocalValueDim});
+        auto var_localStr =
+            io.DefineVariable<std::string>("localStr", {adios2::LocalValueDim});
+
+        auto var_iString = io.DefineVariable<std::string>("iString");
+        auto var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
+        auto var_i16 = io.DefineVariable<int16_t>("i16", shape, start, count);
+        auto var_i32 = io.DefineVariable<int32_t>("i32", shape, start, count);
+        auto var_i64 = io.DefineVariable<int64_t>("i64", shape, start, count);
+        auto var_u8 = io.DefineVariable<uint8_t>("u8", shape, start, count);
+        auto var_u16 = io.DefineVariable<uint16_t>("u16", shape, start, count);
+        auto var_u32 = io.DefineVariable<uint32_t>("u32", shape, start, count);
+        auto var_u64 = io.DefineVariable<uint64_t>("u64", shape, start, count);
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count);
+        auto var_cr32 =
+            io.DefineVariable<std::complex<float>>("cr32", shape, start, count);
+        auto var_cr64 = io.DefineVariable<std::complex<double>>("cr64", shape,
+                                                                start, count);
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+        io.SetParameter("AggregatorRatio", "1");
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            bpWriter.BeginStep();
+
+            const int32_t localNumber = static_cast<int32_t>(mpiRank + step);
+            bpWriter.Put(var_local, localNumber);
+            bpWriter.Put(var_localStr, std::to_string(localNumber));
+
+            bpWriter.Put(var_iString, currentTestData.S1);
+            bpWriter.Put(var_i8, currentTestData.I8.data());
+            bpWriter.Put(var_i16, currentTestData.I16.data());
+            bpWriter.Put(var_i32, currentTestData.I32.data());
+            bpWriter.Put(var_i64, currentTestData.I64.data());
+            bpWriter.Put(var_u8, currentTestData.U8.data());
+            bpWriter.Put(var_u16, currentTestData.U16.data());
+            bpWriter.Put(var_u32, currentTestData.U32.data());
+            bpWriter.Put(var_u64, currentTestData.U64.data());
+            bpWriter.Put(var_r32, currentTestData.R32.data());
+            bpWriter.Put(var_r64, currentTestData.R64.data());
+            bpWriter.Put(var_cr32, currentTestData.CR32.data());
+            bpWriter.Put(var_cr64, currentTestData.CR64.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+#if ADIOS2_USE_MPI
+        adios2_adios *adiosH =
+            adios2_init(MPI_COMM_WORLD, adios2_debug_mode_on);
+#else
+        adios2_adios *adiosH = adios2_init(adios2_debug_mode_on);
+#endif
+        adios2_io *ioR = adios2_declare_io(adiosH, "ReadIO");
+        if (!engineName.empty())
+        {
+            adios2_set_engine(ioR, engineName.data());
+        }
+        else
+        {
+            adios2_set_engine(ioR, "BPFile");
+        }
+
+        adios2_engine *engineR =
+            adios2_open(ioR, fname.data(), adios2_mode_read);
+
+        for (size_t t = 0; t < NSteps; ++t)
+        {
+            adios2_step_status status;
+            adios2_begin_step(engineR, adios2_step_mode_read, -1., &status);
+
+            EXPECT_EQ(status, adios2_step_status_ok);
+
+            {
+                auto *var_local = adios2_inquire_variable(ioR, "local");
+                EXPECT_NE(var_local, nullptr);
+                adios2_varinfo *vi_local =
+                    adios2_inquire_blockinfo(engineR, var_local, 0);
+                CheckStepsBlockInfo1D_C(var_local, vi_local, t, mpiSize, 1);
+            }
+            {
+                auto *var_localStr = adios2_inquire_variable(ioR, "localStr");
+
+                EXPECT_NE(var_localStr, nullptr);
+                adios2_varinfo *vi_localStr =
+                    adios2_inquire_blockinfo(engineR, var_localStr, 0);
+                CheckStepsBlockInfo1D_C(var_localStr, vi_localStr, t, mpiSize,
+                                        1);
+            }
+            {
+                auto *var_iString = adios2_inquire_variable(ioR, "iString");
+                EXPECT_NE(var_iString, nullptr);
+                adios2_varinfo *vi_iString =
+                    adios2_inquire_blockinfo(engineR, var_iString, 0);
+                CheckStepsBlockInfo1D_C(var_iString, vi_iString, t, mpiSize, 1);
+            }
+            {
+                auto *var_i8 = adios2_inquire_variable(ioR, "i8");
+                EXPECT_NE(var_i8, nullptr);
+                adios2_varinfo *vi_i8 =
+                    adios2_inquire_blockinfo(engineR, var_i8, 0);
+                CheckStepsBlockInfo1D_C(var_i8, vi_i8, t, mpiSize, Nx);
+            }
+            {
+                auto *var_r64 = adios2_inquire_variable(ioR, "r64");
+                EXPECT_NE(var_r64, nullptr);
+                adios2_varinfo *vi_r64 =
+                    adios2_inquire_blockinfo(engineR, var_r64, 0);
+                CheckStepsBlockInfo1D_C(var_r64, vi_r64, t, mpiSize, Nx);
+            }
+            /*
+            auto *var_i16 = adios2_inquire_variable(ioR, "i16");
+            auto *var_i32 = adios2_inquire_variable(ioR, "i32");
+            auto *var_i64 = adios2_inquire_variable(ioR, "i64");
+            auto *var_u8 = adios2_inquire_variable(ioR, "u8");
+            auto *var_u16 = adios2_inquire_variable(ioR, "u16");
+            auto *var_u32 = adios2_inquire_variable(ioR, "u32");
+            auto *var_u64 = adios2_inquire_variable(ioR, "u64");
+            auto *var_r32 = adios2_inquire_variable(ioR, "r32");
+
+            auto *var_cr32 = adios2_inquire_variable(ioR, "cr32");
+            auto *var_cr64 = adios2_inquire_variable(ioR, "cr64");
+            */
+
+            adios2_end_step(engineR);
+        }
+        adios2_close(engineR);
     }
 }
 

--- a/testing/adios2/engine/mhs/CMakeLists.txt
+++ b/testing/adios2/engine/mhs/CMakeLists.txt
@@ -5,3 +5,4 @@
 
 gtest_add_tests_helper(SingleRank MPI_NONE Mhs Engine.MHS. "")
 gtest_add_tests_helper(MultiRank MPI_ONLY Mhs Engine.MHS. "")
+gtest_add_tests_helper(MultiReader MPI_ONLY Mhs Engine.MHS. "")

--- a/testing/adios2/engine/mhs/TestMhsMultiReader.cpp
+++ b/testing/adios2/engine/mhs/TestMhsMultiReader.cpp
@@ -1,0 +1,245 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+
+#include "TestMhsCommon.h"
+#include <adios2.h>
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <numeric>
+#include <thread>
+
+using namespace adios2;
+int mpiRank = 0;
+int mpiSize = 1;
+
+char runMode;
+
+class MhsEngineTest : public ::testing::Test
+{
+public:
+    MhsEngineTest() = default;
+};
+
+void Reader(const Dims &shape, const Dims &start, const Dims &count,
+            const size_t rows, const adios2::Params &engineParams,
+            const std::string &name)
+{
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+    adios2::IO io = adios.DeclareIO("ms");
+    io.SetEngine("mhs");
+    io.SetParameters(engineParams);
+    adios2::Engine readerEngine = io.Open(name, adios2::Mode::Read);
+    size_t datasize = 1;
+    for (const auto &i : shape)
+    {
+        datasize *= i;
+    }
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+
+    const auto &vars = io.AvailableVariables();
+    std::cout << "All available variables : ";
+    for (const auto &var : vars)
+    {
+        std::cout << var.first << ", ";
+    }
+    std::cout << std::endl;
+
+    ASSERT_EQ(vars.size(), 10);
+
+    adios2::Variable<char> bpChars = io.InquireVariable<char>("bpChars");
+    adios2::Variable<unsigned char> bpUChars =
+        io.InquireVariable<unsigned char>("bpUChars");
+    adios2::Variable<short> bpShorts = io.InquireVariable<short>("bpShorts");
+    adios2::Variable<unsigned short> bpUShorts =
+        io.InquireVariable<unsigned short>("bpUShorts");
+    adios2::Variable<int> bpInts = io.InquireVariable<int>("bpInts");
+    adios2::Variable<unsigned int> bpUInts =
+        io.InquireVariable<unsigned int>("bpUInts");
+    adios2::Variable<float> bpFloats = io.InquireVariable<float>("bpFloats");
+    adios2::Variable<double> bpDoubles =
+        io.InquireVariable<double>("bpDoubles");
+    adios2::Variable<std::complex<float>> bpComplexes =
+        io.InquireVariable<std::complex<float>>("bpComplexes");
+    adios2::Variable<std::complex<double>> bpDComplexes =
+        io.InquireVariable<std::complex<double>>("bpDComplexes");
+
+    for (size_t step = 0; step < 10; step++)
+    {
+        readerEngine.BeginStep();
+
+        bpChars.SetSelection({start, shape});
+        bpUChars.SetSelection({start, shape});
+        bpShorts.SetSelection({start, shape});
+        bpUShorts.SetSelection({start, shape});
+        bpInts.SetSelection({start, shape});
+        bpUInts.SetSelection({start, shape});
+        bpFloats.SetSelection({start, shape});
+        bpDoubles.SetSelection({start, shape});
+        bpComplexes.SetSelection({start, shape});
+        bpDComplexes.SetSelection({start, shape});
+
+        readerEngine.Get(bpChars, myChars.data(), adios2::Mode::Sync);
+        VerifyData(myChars.data(), step, {0, 0, 0}, shape, shape, "bpChars");
+
+        readerEngine.Get(bpUChars, myUChars.data(), adios2::Mode::Sync);
+        VerifyData(myUChars.data(), step, {0, 0, 0}, shape, shape, "bpUChars");
+
+        readerEngine.Get(bpShorts, myShorts.data(), adios2::Mode::Sync);
+        VerifyData(myShorts.data(), step, {0, 0, 0}, shape, shape, "bpShorts");
+
+        readerEngine.Get(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+        VerifyData(myUShorts.data(), step, {0, 0, 0}, shape, shape,
+                   "bpUShorts");
+
+        readerEngine.Get(bpInts, myInts.data(), adios2::Mode::Sync);
+        VerifyData(myInts.data(), step, {0, 0, 0}, shape, shape, "bpInts");
+
+        readerEngine.Get(bpUInts, myUInts.data(), adios2::Mode::Sync);
+        VerifyData(myUInts.data(), step, {0, 0, 0}, shape, shape, "bpUInts");
+
+        readerEngine.Get(bpFloats, myFloats.data(), adios2::Mode::Sync);
+        VerifyData(myFloats.data(), step, {0, 0, 0}, shape, shape, "bpFloats");
+
+        readerEngine.Get(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+        VerifyData(myDoubles.data(), step, {0, 0, 0}, shape, shape,
+                   "bpDoubles");
+
+        readerEngine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+        VerifyData(myComplexes.data(), step, {0, 0, 0}, shape, shape,
+                   "bpComplexes");
+
+        readerEngine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+        VerifyData(myDComplexes.data(), step, {0, 0, 0}, shape, shape,
+                   "bpDComplexes");
+
+        readerEngine.EndStep();
+    }
+    readerEngine.Close();
+}
+
+void Writer(const Dims &shape, const Dims &start, const Dims &count,
+            const size_t rows, const adios2::Params &engineParams,
+            const std::string &name)
+{
+    size_t datasize = 1;
+    for (const auto &i : count)
+    {
+        datasize *= i;
+    }
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+    adios2::IO io = adios.DeclareIO("ms");
+    io.SetEngine("mhs");
+    io.SetParameters(engineParams);
+    io.AddTransport("sirius", {{"variable", "bpFloats"}});
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+    auto bpChars = io.DefineVariable<char>("bpChars", shape, start, count);
+    auto bpUChars =
+        io.DefineVariable<unsigned char>("bpUChars", shape, start, count);
+    auto bpShorts = io.DefineVariable<short>("bpShorts", shape, start, count);
+    auto bpUShorts =
+        io.DefineVariable<unsigned short>("bpUShorts", shape, start, count);
+    auto bpInts = io.DefineVariable<int>("bpInts", shape, start, count);
+    auto bpUInts =
+        io.DefineVariable<unsigned int>("bpUInts", shape, start, count);
+    auto bpFloats = io.DefineVariable<float>("bpFloats", shape, start, count);
+    auto bpDoubles =
+        io.DefineVariable<double>("bpDoubles", shape, start, count);
+    auto bpComplexes = io.DefineVariable<std::complex<float>>(
+        "bpComplexes", shape, start, count);
+    auto bpDComplexes = io.DefineVariable<std::complex<double>>(
+        "bpDComplexes", shape, start, count);
+    adios2::Engine writerEngine = io.Open(name, adios2::Mode::Write);
+
+    for (size_t step = 0; step < 10; step++)
+    {
+        writerEngine.BeginStep();
+        for (int i = mpiRank; i < static_cast<int>(rows); i += mpiSize)
+        {
+            Dims startRow = start;
+            startRow[0] = i;
+            bpChars.SetSelection({startRow, count});
+            bpUChars.SetSelection({startRow, count});
+            bpShorts.SetSelection({startRow, count});
+            bpUShorts.SetSelection({startRow, count});
+            bpInts.SetSelection({startRow, count});
+            bpUInts.SetSelection({startRow, count});
+            bpFloats.SetSelection({startRow, count});
+            bpDoubles.SetSelection({startRow, count});
+            bpComplexes.SetSelection({startRow, count});
+            bpDComplexes.SetSelection({startRow, count});
+            GenData(myChars, step, startRow, count, shape);
+            GenData(myUChars, step, startRow, count, shape);
+            GenData(myShorts, step, startRow, count, shape);
+            GenData(myUShorts, step, startRow, count, shape);
+            GenData(myInts, step, startRow, count, shape);
+            GenData(myUInts, step, startRow, count, shape);
+            GenData(myFloats, step, startRow, count, shape);
+            GenData(myDoubles, step, startRow, count, shape);
+            GenData(myComplexes, step, startRow, count, shape);
+            GenData(myDComplexes, step, startRow, count, shape);
+            writerEngine.Put(bpChars, myChars.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpUChars, myUChars.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpShorts, myShorts.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpInts, myInts.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpUInts, myUInts.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpFloats, myFloats.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+            writerEngine.Put(bpComplexes, myComplexes.data(),
+                             adios2::Mode::Sync);
+            writerEngine.Put(bpDComplexes, myDComplexes.data(),
+                             adios2::Mode::Sync);
+        }
+        writerEngine.EndStep();
+    }
+    writerEngine.Close();
+}
+
+TEST_F(MhsEngineTest, TestMhsMultiReader)
+{
+    std::string filename = "TestMhsMultiReader";
+    adios2::Params engineParams = {{"Verbose", "0"}, {"Tiers", "4"}};
+
+    size_t rows = 32;
+    Dims shape = {rows, 8, 16};
+    Dims start = {0, 0, 0};
+    Dims count = {1, 8, 16};
+
+    Writer(shape, start, count, rows, engineParams, filename);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    Reader(shape, start, count, rows, engineParams, filename);
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
+}

--- a/testing/adios2/engine/staging-common/run_test.py.gen.in
+++ b/testing/adios2/engine/staging-common/run_test.py.gen.in
@@ -321,6 +321,13 @@ reader_command_line.extend([reader_executable, canonical_engine, args.filename])
 if args.rarg is not None:
     reader_command_line.extend(args.rarg)
 
+if args.num_writers == 0:
+    writer_command_line = None
+    mpmd_possible = False
+    print("TestDriver: No writers, setting MPMD false\n")
+else:
+    print("TestDriver: Writer command line : " + " ".join(writer_command_line))
+
 if args.num_readers == 0:
     reader_command_line = None
     mpmd_possible = False
@@ -328,13 +335,6 @@ if args.num_readers == 0:
 
 else:
     print("TestDriver: Reader command line : " + " ".join(reader_command_line))
-
-if args.num_writers == 0:
-    writer_command_line = None
-    mpmd_possible = False
-    print("TestDriver: No writers, setting MPMD false\n")
-else:
-    print("TestDriver: Writer command line : " + " ".join(writer_command_line))
 
 if is_file_engine[args.engine.lower()]:
     print("TestDriver: Is file engine, setting MPMD false\n")

--- a/testing/h5vol/TestH5VolWriteReadBPFile.cpp
+++ b/testing/h5vol/TestH5VolWriteReadBPFile.cpp
@@ -209,12 +209,14 @@ void HDF5NativeWriter::CreateAndStoreScalar(std::string const &variableName,
                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
         ret = H5Dwrite(dsetID, type, H5S_ALL, H5S_ALL, plistID, values);
+        EXPECT_GE(ret, 0);
 
 #ifdef DOUBLECHECK
         size_t typesize = H5Tget_size(type);
         char *val = (char *)(calloc(typesize, sizeof(char)));
 
         hid_t ret2 = H5Dread(dsetID, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, val);
+        EXPECT_GE(ret2, 0);
         std::cerr << "        ....  typesize=" << typesize << "  val=" << val
                   << std::endl;
         free val;


### PR DESCRIPTION
 If WriteV() has zero data to write, still seek to the start position if set by caller.

This fixes the Engine.BP.BPWriteReadTestADIOS2.ADIOS2BPWriteReadEmptyProcess.BP5.MPI test