### PR TITLE
Bp5 random fix zero

### DIFF
--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -38,6 +38,10 @@ void Transport::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
             Write(static_cast<const char *>(iov[c].iov_base), iov[c].iov_len);
         }
     }
+    else if (start != MaxSizeT)
+    {
+        Seek(start);
+    }
 }
 
 void Transport::IRead(char *buffer, size_t size, Status &status, size_t start)

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -152,6 +152,8 @@ public:
 
     virtual void SeekToBegin() = 0;
 
+    virtual void Seek(const size_t start = MaxSizeT) = 0;
+
 protected:
     virtual void MkDir(const std::string &fileName);
 

--- a/source/adios2/toolkit/transport/file/FileDaos.cpp
+++ b/source/adios2/toolkit/transport/file/FileDaos.cpp
@@ -338,5 +338,27 @@ void FileDaos::SeekToBegin()
     }
 }
 
+void FileDaos::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        errno = 0;
+        const int status = lseek(m_FileDescriptor, start, SEEK_SET);
+        m_Errno = errno;
+        if (status == -1)
+        {
+            throw std::ios_base::failure("ERROR: couldn't seek to offset " +
+                                         std::to_string(start) + " of file " +
+                                         m_Name + ", in call to DAOS IO lseek" +
+                                         SysErrMsg());
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileDaos.h
+++ b/source/adios2/toolkit/transport/file/FileDaos.h
@@ -52,6 +52,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** DAOS file handle returned by Open */
     int m_FileDescriptor = -1;

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -339,5 +339,20 @@ void FileFStream::SeekToBegin()
               ", in call to fstream seekp");
 }
 
+void FileFStream::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        m_FileStream.seekp(start, std::ios_base::beg);
+        CheckFile("couldn't move to offset " + std::to_string(start) +
+                  " of file " + m_Name + ", in call to fstream seekp");
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileFStream.h
+++ b/source/adios2/toolkit/transport/file/FileFStream.h
@@ -57,6 +57,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** file stream using fstream library */
     std::fstream m_FileStream;

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -336,5 +336,24 @@ void FileIME::SeekToBegin()
     }
 }
 
+void FileIME::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        const int status =
+            ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
+        if (status == -1)
+        {
+            throw std::ios_base::failure(
+                "ERROR: couldn't seek to offset " + std::to_string(start) +
+                " of file " + m_Name + ", in call to IME IO lseek\n");
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -57,6 +57,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** POSIX file handle returned by Open */
     int m_FileDescriptor = -1;

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -533,5 +533,27 @@ void FilePOSIX::SeekToBegin()
     }
 }
 
+void FilePOSIX::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        errno = 0;
+        const int status = lseek(m_FileDescriptor, start, SEEK_SET);
+        m_Errno = errno;
+        if (status == -1)
+        {
+            throw std::ios_base::failure(
+                "ERROR: couldn't seek to offset " + std::to_string(start) +
+                " of file " + m_Name + ", in call to POSIX IO lseek" +
+                SysErrMsg());
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -64,6 +64,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** POSIX file handle returned by Open */
     int m_FileDescriptor = -1;

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -359,5 +359,24 @@ void FileStdio::SeekToBegin()
     }
 }
 
+void FileStdio::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        WaitForOpen();
+        const auto status = std::fseek(m_File, 0, SEEK_SET);
+        if (status == -1)
+        {
+            throw std::ios_base::failure("ERROR: couldn't seek to offset " +
+                                         std::to_string(start) + " of file " +
+                                         m_Name + ", in call to stdio fseek\n");
+        }
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
 } // end namespace transport
 } // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -55,6 +55,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start) final;
+
 private:
     /** C File pointer */
     FILE *m_File = nullptr;

--- a/source/adios2/toolkit/transport/null/NullTransport.cpp
+++ b/source/adios2/toolkit/transport/null/NullTransport.cpp
@@ -131,6 +131,16 @@ void NullTransport::SeekToBegin()
     Impl->CurPos = 0;
 }
 
+void NullTransport::Seek(const size_t start)
+{
+    if (!Impl->IsOpen)
+    {
+        throw std::runtime_error(
+            "ERROR: NullTransport::SeekToEnd: The transport is not open.");
+    }
+    Impl->CurPos = start;
+}
+
 void NullTransport::MkDir(const std::string &fileName) { return; }
 
 void NullTransport::CheckName() const { return; }

--- a/source/adios2/toolkit/transport/null/NullTransport.h
+++ b/source/adios2/toolkit/transport/null/NullTransport.h
@@ -56,6 +56,8 @@ public:
 
     void SeekToBegin() override;
 
+    void Seek(const size_t start = MaxSizeT) override;
+
 protected:
     struct NullTransportImpl;
     std::unique_ptr<NullTransportImpl> Impl;

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
@@ -145,6 +145,11 @@ void ShmSystemV::SeekToBegin()
     // empty function. seek operation is meaningless for shared memory
 }
 
+void ShmSystemV::Seek(const size_t start)
+{
+    // empty function. seek operation is meaningless for shared memory
+}
+
 // PRIVATE
 void ShmSystemV::CheckShmID(const std::string hint) const
 {

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.h
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.h
@@ -51,6 +51,8 @@ public:
 
     void SeekToBegin() final;
 
+    void Seek(const size_t start = MaxSizeT) final;
+
 private:
     /** 1st argument of ftok to create shared memory segment key, from Open */
     std::string m_PathName;

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -1935,12 +1935,12 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteReadEmptyProcess)
                 // in first step, rank 0 does not call Put
                 // in second step, it calls with a zero sized array
                 // in third step, it calls with nullptr
-                if (step == 1)
+                if (step == 3)
                 {
                     std::vector<float> zero;
                     bpWriter.Put(var_r32, zero.data());
                 }
-                else if (step == 2)
+                else if (step == 3)
                 {
                     bpWriter.Put(var_r32, (float *)0);
                 }

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -1935,12 +1935,12 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteReadEmptyProcess)
                 // in first step, rank 0 does not call Put
                 // in second step, it calls with a zero sized array
                 // in third step, it calls with nullptr
-                if (step == 3)
+                if (step == 1)
                 {
                     std::vector<float> zero;
                     bpWriter.Put(var_r32, zero.data());
                 }
-                else if (step == 3)
+                else if (step == 2)
                 {
                     bpWriter.Put(var_r32, (float *)0);
                 }


### PR DESCRIPTION
If WriteV() has zero data to write, still seek to the start position if set by caller.

This fixes the test Engine.BP.BPWriteReadTestADIOS2.ADIOS2BPWriteReadEmptyProcess.BP5.MPI