### PR TITLE
S3 write support: Some fixes

### DIFF
--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -177,7 +177,10 @@ public:
     MACRO(MaxOpenFilesAtOnce, UInt, unsigned int, UINT_MAX)                                        \
     MACRO(DataTransport, String, std::string, "")                                                  \
     MACRO(S3Endpoint, String, std::string, "")                                                     \
-    MACRO(S3Bucket, String, std::string, "")
+    MACRO(S3Bucket, String, std::string, "")                                                       \
+    MACRO(S3AccessKeyID, String, std::string, "")                                                  \
+    MACRO(S3SecretKey, String, std::string, "")                                                    \
+    MACRO(S3SessionToken, String, std::string, "")
 
     struct BP5Params
     {

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -1442,6 +1442,18 @@ void BP5Reader::InitTransports()
         {
             dataTransportParams["bucket"] = m_Parameters.S3Bucket;
         }
+        if (!m_Parameters.S3AccessKeyID.empty())
+        {
+            dataTransportParams["AccessKeyID"] = m_Parameters.S3AccessKeyID;
+        }
+        if (!m_Parameters.S3SecretKey.empty())
+        {
+            dataTransportParams["SecretKey"] = m_Parameters.S3SecretKey;
+        }
+        if (!m_Parameters.S3SessionToken.empty())
+        {
+            dataTransportParams["SessionToken"] = m_Parameters.S3SessionToken;
+        }
         // Pass verbose level to transport
         if (m_Parameters.verbose > 0)
         {

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -1598,6 +1598,18 @@ void BP5Writer::InitMetadataTransports()
         {
             dataTransportParams["bucket"] = m_Parameters.S3Bucket;
         }
+        if (!m_Parameters.S3AccessKeyID.empty())
+        {
+            dataTransportParams["AccessKeyID"] = m_Parameters.S3AccessKeyID;
+        }
+        if (!m_Parameters.S3SecretKey.empty())
+        {
+            dataTransportParams["SecretKey"] = m_Parameters.S3SecretKey;
+        }
+        if (!m_Parameters.S3SessionToken.empty())
+        {
+            dataTransportParams["SessionToken"] = m_Parameters.S3SessionToken;
+        }
         // Pass verbose level to transport
         if (m_Parameters.verbose > 0)
         {

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -305,7 +305,9 @@ void FileAWSSDK::Open(const std::string &name, const Mode openMode, const bool a
         m_BucketName = m_BucketPrefix;
         m_ObjectName = name;
         // Strip leading slashes from object key (S3 keys shouldn't start with /)
-        while (!m_ObjectName.empty() && m_ObjectName[0] == PathSeparator)
+        // Also strip leading dots, those lead to authentication issues
+        while (!m_ObjectName.empty() &&
+               (m_ObjectName[0] == PathSeparator || m_ObjectName[0] == '.'))
         {
             m_ObjectName = m_ObjectName.substr(1);
         }

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -50,6 +50,11 @@ void FileAWSSDK::SetParameters(const Params &params)
     // Parameters are set from config parameters if present
     // Otherwise, they are set from environment if present
     // Otherwise, they remain at their default value
+    //
+    for (auto const&[l, r]: params)
+    {
+        std::cout << "PARAM:\t" << l << ":\t" << r << std::endl;
+    }
 
     helper::SetParameterValue("endpoint", params, m_Endpoint);
     if (m_Endpoint.empty())
@@ -155,6 +160,7 @@ void FileAWSSDK::SetParameters(const Params &params)
 
     if (!m_accessKeyID.empty() || !m_secretKey.empty())
     {
+        std::cout << "Configuring with secret key." << std::endl;
         Aws::Auth::AWSCredentials aws_credentials;
         if (!m_sessionToken.empty())
         {
@@ -170,6 +176,7 @@ void FileAWSSDK::SetParameters(const Params &params)
     }
     else
     {
+        std::cout << "Configuring without secret key." << std::endl;
         s3Client = new Aws::S3::S3Client(*s3ClientConfig);
     }
     if (m_Verbose > 0)

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -78,7 +78,7 @@ void FileAWSSDK::SetParameters(const Params &params)
         }
     }
 
-    helper::SetParameterValue("accessKeyID", params, m_accessKeyID);
+    helper::SetParameterValue("accesskeyid", params, m_accessKeyID);
     if (m_accessKeyID.empty())
     {
         if (const char *Env = std::getenv("AWS_ACCESS_KEY_ID"))
@@ -86,7 +86,7 @@ void FileAWSSDK::SetParameters(const Params &params)
             m_accessKeyID = std::string(Env);
         }
     }
-    helper::SetParameterValue("secretKey", params, m_secretKey);
+    helper::SetParameterValue("secretkey", params, m_secretKey);
     if (m_secretKey.empty())
     {
         if (const char *Env = std::getenv("AWS_SECRET_KEY"))
@@ -94,7 +94,7 @@ void FileAWSSDK::SetParameters(const Params &params)
             m_secretKey = std::string(Env);
         }
     }
-    helper::SetParameterValue("sessionToken", params, m_sessionToken);
+    helper::SetParameterValue("sessiontoken", params, m_sessionToken);
     if (m_sessionToken.empty())
     {
         if (const char *Env = std::getenv("AWS_SESSION_TOKEN"))

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -50,11 +50,6 @@ void FileAWSSDK::SetParameters(const Params &params)
     // Parameters are set from config parameters if present
     // Otherwise, they are set from environment if present
     // Otherwise, they remain at their default value
-    //
-    for (auto const&[l, r]: params)
-    {
-        std::cout << "PARAM:\t" << l << ":\t" << r << std::endl;
-    }
 
     helper::SetParameterValue("endpoint", params, m_Endpoint);
     if (m_Endpoint.empty())
@@ -160,7 +155,6 @@ void FileAWSSDK::SetParameters(const Params &params)
 
     if (!m_accessKeyID.empty() || !m_secretKey.empty())
     {
-        std::cout << "Configuring with secret key." << std::endl;
         Aws::Auth::AWSCredentials aws_credentials;
         if (!m_sessionToken.empty())
         {
@@ -176,7 +170,6 @@ void FileAWSSDK::SetParameters(const Params &params)
     }
     else
     {
-        std::cout << "Configuring without secret key." << std::endl;
         s3Client = new Aws::S3::S3Client(*s3ClientConfig);
     }
     if (m_Verbose > 0)

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.h
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.h
@@ -19,6 +19,7 @@
 #include "adios2/toolkit/transport/file/FileFStream.h"
 
 #include <aws/core/Aws.h>
+#include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/utils/logging/LogLevel.h>
 #include <aws/core/utils/stream/PreallocatedStreamBuf.h>
 #include <aws/s3/S3Client.h>
@@ -97,6 +98,9 @@ private:
     /** AWSSDK file handle returned by Open */
     std::string m_Endpoint;
     std::string m_BucketPrefix; // Bucket to prepend to paths (from "bucket" parameter)
+    std::string m_accessKeyID;
+    std::string m_secretKey;
+    std::string m_sessionToken;
     Aws::S3::Model::HeadObjectOutcome head_object;
     std::string m_BucketName;
     std::string m_ObjectName;


### PR DESCRIPTION
This adds:

* Parameters S3AccessKeyID, S3SecretKey, S3SessionToken for authentication
* Detection of leading dots, those apparently lead to authentication issues. Now, key names such as `./s3.bp5/data.0` are transformed to `s3.bp5/data.0`